### PR TITLE
Experiment: Rendering via GPU

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     ]
   },
   "peerDependencies": {
-    "ocaml": "~4.6.0"
+    "ocaml": "~4.7.0"
   },
   "dependencies": {
     "@esy-ocaml/reason": "*",
@@ -31,8 +31,7 @@
     "yarn-pkg-config": "*"
   },
   "devDependencies": {
-    "@esy-ocaml/merlin": "*",
-    "ocaml": "~4.6.0"
+    "ocaml": "~4.7.0"
   },
   "resolutions": {
     "@opam/ocaml-migrate-parsetree": "1.1.0",

--- a/src/wrapped/bindings/SkiaWrappedBindings.re
+++ b/src/wrapped/bindings/SkiaWrappedBindings.re
@@ -12,6 +12,12 @@ module M = (F: Ctypes.FOREIGN) => {
       "draw_main",
       C.(SkiaWrappedBindingsTypes.Base.void @-> returning(int)),
     );
+  
+  let imported_draw_gpu =
+    foreign(
+      "draw_gpu",
+      C.(SkiaWrappedBindingsTypes.Base.void @-> returning(int)),
+    );
 
   let imported_my_c_function =
     foreign(

--- a/src/wrapped/c/draw_main.c
+++ b/src/wrapped/c/draw_main.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "include/c/gr_context.h"
 #include "include/c/sk_canvas.h"
 #include "include/c/sk_data.h"
 #include "include/c/sk_image.h"
@@ -78,3 +79,39 @@ int draw_main() {
     sk_surface_unref(surface);
     return 0;
 }
+
+
+
+int draw_gpu() {
+    //const gr_glinterface_t* interface = gr_glinterface_create_native_interface();
+    //printf("got interface!");
+    printf("making context\n");
+    gr_context_t* context = gr_context_make_gl(NULL);
+
+    printf("making rt\n");
+    gr_gl_framebufferinfo_t fbInfo;
+    fbInfo.fFBOID = 0;
+    fbInfo.fFormat = 0x8058; //GR_GL_RGBA8;
+    gr_backendrendertarget_t* rt = gr_backendrendertarget_new_gl(640, 800, 0, 8, &fbInfo);
+    printf("creating surface props\n");
+    sk_surfaceprops_t* props = sk_surfaceprops_new(0, UNKNOWN_SK_PIXELGEOMETRY);
+    printf("creating info\n");
+    sk_imageinfo_t* info = malloc(sizeof(sk_imageinfo_t));
+    *info = (sk_imageinfo_t){ .width = 640, .height = 800, .colorType = RGBA_8888_SK_COLORTYPE,
+                                            .alphaType = PREMUL_SK_ALPHATYPE, .colorspace = NULL };
+    printf("creating render target\n");
+    //sk_surface_t* surface = sk_surface_new_render_target(context, false, info, 1, TOP_LEFT_GR_SURFACE_ORIGIN, props, false);
+    sk_surface_t* surface = sk_surface_new_backend_render_target(context, rt, TOP_LEFT_GR_SURFACE_ORIGIN, RGBA_8888_SK_COLORTYPE, NULL, props);
+    printf("creating canvas\n");
+    if (!surface) {
+        printf("Surface is NULL!\n");
+    }
+    sk_canvas_t* canvas = sk_surface_get_canvas(surface);
+    printf("drawing\n");
+    draw(canvas);
+    printf("flushing\n");
+    //gr_context_flush(context);
+    sk_canvas_flush(canvas);
+    printf("flushed\n");
+    return 0;
+};

--- a/src/wrapped/c/draw_main.c
+++ b/src/wrapped/c/draw_main.c
@@ -34,16 +34,16 @@ static void emit_png(const char* path, sk_surface_t* surface) {
 
 void draw(sk_canvas_t* canvas) {
     sk_paint_t* fill = sk_paint_new();
-    sk_paint_set_color(fill, sk_color_set_argb(0xFF, 0x00, 0x00, 0xFF));
+    sk_paint_set_color(fill, sk_color_set_argb(0x00, 0x00, 0x00, 0xFF));
     sk_canvas_draw_paint(canvas, fill);
 
-    sk_paint_set_color(fill, sk_color_set_argb(0xFF, 0x00, 0xFF, 0xFF));
+    /*sk_paint_set_color(fill, sk_color_set_argb(0x00, 0x00, 0x00, 0xFF));
     sk_rect_t rect;
     rect.left = 100.0f;
     rect.top = 100.0f;
     rect.right = 540.0f;
     rect.bottom = 380.0f;
-    sk_canvas_draw_rect(canvas, &rect, fill);
+    sk_canvas_draw_rect(canvas, &rect, fill);*/
 
     sk_paint_t* stroke = sk_paint_new();
     sk_paint_set_color(stroke, sk_color_set_argb(0xFF, 0xFF, 0x00, 0x00));
@@ -65,6 +65,19 @@ void draw(sk_canvas_t* canvas) {
     rect2.right = 520.0f;
     rect2.bottom = 360.0f;
     sk_canvas_draw_oval(canvas, &rect2, fill);
+    /*sk_canvas_draw_paint(canvas, fill);*/
+
+    sk_fontstyle_t *style = sk_fontstyle_new(500, 0, UPRIGHT_SK_FONT_STYLE_SLANT);
+    sk_typeface_t *typeface = sk_typeface_create_from_name_with_font_style("Consolas", style);
+    char* familyName = (char *)sk_typeface_get_family_name(typeface);
+    printf("Family name: %s\n", familyName);
+    sk_paint_t* fill2 = sk_paint_new();
+    sk_paint_set_color(fill2, sk_color_set_argb(0xFF, 0xFF, 0xFF, 0xFF));
+    sk_paint_set_typeface(fill2, typeface);
+    sk_paint_set_lcd_render_text(fill2, true);
+    printf("LCD TEXT: %d\n", sk_paint_is_lcd_render_text(fill2));
+    sk_paint_set_antialias(fill2, true);
+    sk_canvas_draw_text(canvas, "Hello, world!", strlen("Hello, world!"), 10.25, 10.25, fill2);
 
     sk_path_delete(path);
     sk_paint_delete(stroke);
@@ -92,16 +105,16 @@ int draw_gpu() {
     gr_gl_framebufferinfo_t fbInfo;
     fbInfo.fFBOID = 0;
     fbInfo.fFormat = 0x8058; //GR_GL_RGBA8;
-    gr_backendrendertarget_t* rt = gr_backendrendertarget_new_gl(640, 800, 0, 8, &fbInfo);
+    gr_backendrendertarget_t* rt = gr_backendrendertarget_new_gl(640, 400, 8, 8, &fbInfo);
     printf("creating surface props\n");
-    sk_surfaceprops_t* props = sk_surfaceprops_new(0, UNKNOWN_SK_PIXELGEOMETRY);
+    sk_surfaceprops_t* props = sk_surfaceprops_new(0, RGB_H_SK_PIXELGEOMETRY);
     printf("creating info\n");
     sk_imageinfo_t* info = malloc(sizeof(sk_imageinfo_t));
-    *info = (sk_imageinfo_t){ .width = 640, .height = 800, .colorType = RGBA_8888_SK_COLORTYPE,
-                                            .alphaType = PREMUL_SK_ALPHATYPE, .colorspace = NULL };
+    *info = (sk_imageinfo_t){ .width = 640, .height = 400, .colorType = RGBA_8888_SK_COLORTYPE,
+                                            .alphaType = UNPREMUL_SK_ALPHATYPE, .colorspace = NULL };
     printf("creating render target\n");
     //sk_surface_t* surface = sk_surface_new_render_target(context, false, info, 1, TOP_LEFT_GR_SURFACE_ORIGIN, props, false);
-    sk_surface_t* surface = sk_surface_new_backend_render_target(context, rt, TOP_LEFT_GR_SURFACE_ORIGIN, RGBA_8888_SK_COLORTYPE, NULL, props);
+    sk_surface_t* surface = sk_surface_new_backend_render_target(context, rt, BOTTOM_LEFT_GR_SURFACE_ORIGIN, RGBA_8888_SK_COLORTYPE, NULL, props);
     printf("creating canvas\n");
     if (!surface) {
         printf("Surface is NULL!\n");


### PR DESCRIPTION
This adds a `draw_gpu` method to experiment with rendering in an OpenGL context (I'm testing it out here: https://github.com/bryphe/reason-glfw-skia

Not necessary to merge; but something we'll have to investigate as we continue to iterate.

This should be split it into initialization (creating the surface / canvas) and then rendering. Also needs to take into account aspects like the window width / height.