### PR TITLE
CI: Publish example image for CentOS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,4 +110,8 @@ jobs:
   - script: docker run --rm --mount src=`pwd`,target=/reason-skia,type=bind centos /bin/bash -c 'which ragel'
   - script: docker run --rm --mount src=`pwd`,target=/reason-skia,type=bind centos /bin/bash -c 'cd reason-skia && ls -a'
   - script: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --rm --mount src=`pwd`,target=/reason-skia,type=bind centos /bin/bash -c 'cd reason-skia && ./build/docker-build.sh'
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: 'skia-c-example.png'
+      artifactName: 'skia-c-example-centos7.png'
 


### PR DESCRIPTION
With this change - I can see the output image for all platforms:
![image](https://user-images.githubusercontent.com/13532591/72630545-6b8a4700-3907-11ea-89f1-fa105b37acc5.png)
