### PR TITLE
Bugfix: Remove debug logging

### DIFF
--- a/src/Skia.re
+++ b/src/Skia.re
@@ -424,11 +424,6 @@ module Canvas = {
   let clipRect = SkiaWrapped.Canvas.clipRect;
   let clipPath = SkiaWrapped.Canvas.clipPath;
   let clipRRect = (canvas, rrect, clipOp: clipOp, antiAlias) => {
-    let output =
-      switch (clipOp) {
-      | Intersect => "Intersect"
-      | Difference => "Difference"
-      };
     SkiaWrapped.Canvas.clipRRect(canvas, rrect, clipOp, antiAlias);
   };
 

--- a/src/Skia.re
+++ b/src/Skia.re
@@ -429,7 +429,6 @@ module Canvas = {
       | Intersect => "Intersect"
       | Difference => "Difference"
       };
-    print_endline("clipOp: " ++ output);
     SkiaWrapped.Canvas.clipRRect(canvas, rrect, clipOp, antiAlias);
   };
 


### PR DESCRIPTION
The debug logging causes crashes on Windows when not attached to a console