### PR TITLE
[PoC] Perf - Experiment: Example of using raw, noalloc bindings

### DIFF
--- a/example/TestApp.re
+++ b/example/TestApp.re
@@ -162,7 +162,7 @@ let draw = canvas => {
   let fill = Paint.make();
   Paint.setColor(fill, Color.makeArgb(0xFF, 0xFF, 0x00, 0xFF));
   Canvas.drawRectLtwh(canvas, 50., 75., 100., 200., fill);
-Skia.Canvas.superTest(canvas);
+  Skia.Canvas.superTest(canvas);
 };
 
 let surface = makeSurface(640l, 480l);

--- a/example/TestApp.re
+++ b/example/TestApp.re
@@ -162,6 +162,7 @@ let draw = canvas => {
   let fill = Paint.make();
   Paint.setColor(fill, Color.makeArgb(0xFF, 0xFF, 0x00, 0xFF));
   Canvas.drawRectLtwh(canvas, 50., 75., 100., 200., fill);
+Skia.Canvas.superTest(canvas);
 };
 
 let surface = makeSurface(640l, 480l);

--- a/src/Skia.re
+++ b/src/Skia.re
@@ -438,9 +438,10 @@ module Canvas = {
     );
 
   module CI = Cstubs_internals;
-  [@noalloc] external _superTest: CI.fatptr(_) => unit = "reason_skia_raw_binding_test";
+  [@noalloc]
+  external _superTest: CI.fatptr(_) => unit = "reason_skia_raw_binding_test";
 
-  let superTest = (canvas) => _superTest(CI.cptr(canvas));
+  let superTest = canvas => _superTest(CI.cptr(canvas));
 
   let drawPaint = SkiaWrapped.Canvas.drawPaint;
   let drawRect = SkiaWrapped.Canvas.drawRect;

--- a/src/Skia.re
+++ b/src/Skia.re
@@ -437,6 +437,11 @@ module Canvas = {
       Ctypes.structure(SkiaWrappedBindings.SkiaTypes.Canvas.t),
     );
 
+  module CI = Cstubs_internals;
+  [@noalloc] external _superTest: CI.fatptr(_) => unit = "reason_skia_raw_binding_test";
+
+  let superTest = (canvas) => _superTest(CI.cptr(canvas));
+
   let drawPaint = SkiaWrapped.Canvas.drawPaint;
   let drawRect = SkiaWrapped.Canvas.drawRect;
   let drawRectLtwh = SkiaWrapped.Canvas.drawRectLtwh;

--- a/src/Skia.rei
+++ b/src/Skia.rei
@@ -300,8 +300,7 @@ type clipOp = SkiaWrapped.clipOp;
 
 module Canvas: {
   type t;
-let superTest: t => unit;
-
+  let superTest: t => unit;
 
   let drawPaint: (t, Paint.t) => unit;
   let drawRect: (t, Rect.t, Paint.t) => unit;

--- a/src/Skia.rei
+++ b/src/Skia.rei
@@ -300,6 +300,8 @@ type clipOp = SkiaWrapped.clipOp;
 
 module Canvas: {
   type t;
+let superTest: t => unit;
+
 
   let drawPaint: (t, Paint.t) => unit;
   let drawRect: (t, Rect.t, Paint.t) => unit;

--- a/src/wrapped/c/c_stubs.c
+++ b/src/wrapped/c/c_stubs.c
@@ -7,7 +7,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-
 sk_color_t reason_skia_stub_sk_color_set_argb(int alpha, int red, int green, int blue)
 {
     return sk_color_set_argb(alpha, red, green, blue);
@@ -42,5 +41,6 @@ sk_canvas_t *canvas, float left, float top, float width, float height, sk_paint_
     rect.right = left + width;
     rect.bottom = top + height;
 
+    printf("Real Canvas: %p\n", (void *)canvas);
     sk_canvas_draw_rect(canvas, &rect, paint);
 }

--- a/src/wrapped/lib/dune
+++ b/src/wrapped/lib/dune
@@ -13,6 +13,6 @@
   (flags (-w -40 -w +26))
   (public_name skia.wrapped)
   (libraries skia.wrapped.types skia.wrapped.bindings ctypes ctypes.foreign)
-  (c_names skia_generated_stubs)
+  (c_names skia_generated_stubs raw_bindings)
   (c_flags (:include ../../c_flags.sexp))
   (c_library_flags (:include ../../c_library_flags.sexp)))

--- a/src/wrapped/lib/raw_bindings.c
+++ b/src/wrapped/lib/raw_bindings.c
@@ -1,0 +1,25 @@
+/*
+ * Use this file for building any C-layer functionality that we want to keep out of Reason
+ */
+
+#include "c_stubs.h"
+#include "sk_canvas.h"
+#include "sk_paint.h"
+#include "sk_types.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "ctypes_cstubs_internals.h"
+
+CAMLprim value reason_skia_raw_binding_test(value vCanvas) {
+   //CAMLparam1(vCanvas);
+   printf("Got here...\n");
+   void* pCanvas = CTYPES_ADDR_OF_FATPTR(vCanvas);
+   printf("Fake canvas: %p\n", pCanvas);
+   printf("And here...\n");
+   return Val_unit;
+   //CAMLreturn(Val_unit);
+}
+
+


### PR DESCRIPTION
Right now, `ctypes` unfortunately does not support generating `[@noalloc]` and unboxed floats: https://github.com/ocamllabs/ocaml-ctypes/issues/132 

These are important to squeeze the most perf out of the C FFI. This is a proof-of-concept of a workaround right now for methods that are bottlenecking performance - but the best thing would be to contribute a fix for `ctypes`.