### PR TITLE
Bugfix: Skip pkg-config; statically link libjpeg binary on OSX

### DIFF
--- a/src/config/discover.re
+++ b/src/config/discover.re
@@ -41,8 +41,13 @@ let () =
         }
       };
 
+    let join = String.concat("|");
+    print_endline("conf.cflags: " ++ join(conf.cflags));
+    print_endline("conf.libs: " ++ join(conf.libs));
+
     let ccopt = s => ["-ccopt", s];
     let cclib = s => ["-cclib", s];
+    let framework = s => ["-framework", s];
     let flags =
       switch (get_os) {
       | Linux =>
@@ -66,6 +71,10 @@ let () =
 
     let cflags =
       switch (get_os) {
+      | Mac =>
+        []
+        @ ["-I" ++ Sys.getenv("SKIA_INCLUDE_PATH")]
+        @ ["-I" ++ Sys.getenv("SKIA_INCLUDE_PATH") ++ "/c"]
       | Linux =>
         //conf.cflags
         []
@@ -81,6 +90,18 @@ let () =
 
     let libs =
       switch (get_os) {
+      | Mac =>
+        []
+        @ ["-L" ++ Sys.getenv("JPEG_LIB_PATH")]
+        @ ["-L" ++ Sys.getenv("SKIA_LIB_PATH")]
+        @ ["-L" ++ Sys.getenv("FREETYPE2_LIB_PATH")]
+        @ framework("CoreServices")
+        @ framework("CoreGraphics")
+        @ framework("CoreText")
+        @ framework("CoreFoundation")
+        @ ["-lskia"]
+        @ ["-lstdc++"]
+        @ [Sys.getenv("JPEG_LIB_PATH") ++ "/libturbojpeg.a"]
       | Linux =>
         //conf.libs
         []

--- a/src/config/discover.re
+++ b/src/config/discover.re
@@ -41,10 +41,6 @@ let () =
         }
       };
 
-    let join = String.concat("|");
-    print_endline("conf.cflags: " ++ join(conf.cflags));
-    print_endline("conf.libs: " ++ join(conf.libs));
-
     let ccopt = s => ["-ccopt", s];
     let cclib = s => ["-cclib", s];
     let framework = s => ["-framework", s];


### PR DESCRIPTION
Should fix: https://github.com/revery-ui/revery/issues/742

This skips `pkg-config` for OSX and manually specifies link / include flags. In particular, it forces static linking of our locally built `libjpegturbo` to ensure that we don't conflict with a homebrew or system install.

This also seems to fix the packaging issue in https://github.com/onivim/oni2/pull/1251, which was due to an `@rpath` in the library dependency list: `@rpath/libjpeg.62.dylib (compatibility version 62.0.0, current version 62.3.0)` (via running `otool -L` on `Oni2_editor.exe`)