### PR TITLE
Statically link libffi

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "d3a8ac67af5669dde6609eb3f0c68ae4",
+  "checksum": "9ebf8e243cf3d7bf2015e4a7ba73ba66",
   "root": "reason-skia@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -828,7 +828,7 @@
         "@opam/conf-pkg-config@opam:1.1@67c69c0c",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9",
-        "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9"
+        "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/integers@opam:0.3.0@d6eefd3a",
@@ -1132,13 +1132,13 @@
       ],
       "devDependencies": []
     },
-    "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9": {
-      "id": "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9",
+    "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9": {
+      "id": "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9",
       "name": "@esy-ocaml/libffi",
-      "version": "github:glennsl/libffi#0d21ddb",
+      "version": "github:esy-ocaml/libffi#c61127d",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/libffi#0d21ddb" ]
+        "source": [ "github:esy-ocaml/libffi#c61127d" ]
       },
       "overrides": [],
       "dependencies": [],

--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "0b50219201b8602720c63b16c472a00f",
+  "checksum": "d3a8ac67af5669dde6609eb3f0c68ae4",
   "root": "reason-skia@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -828,7 +828,7 @@
         "@opam/conf-pkg-config@opam:1.1@67c69c0c",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9",
-        "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa@d41d8cd9"
+        "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/integers@opam:0.3.0@d6eefd3a",
@@ -1132,17 +1132,13 @@
       ],
       "devDependencies": []
     },
-    "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa@d41d8cd9": {
-      "id":
-        "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa@d41d8cd9",
+    "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9": {
+      "id": "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9",
       "name": "@esy-ocaml/libffi",
-      "version":
-        "github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa",
+      "version": "github:glennsl/libffi#0d21ddb",
       "source": {
         "type": "install",
-        "source": [
-          "github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa"
-        ]
+        "source": [ "github:glennsl/libffi#0d21ddb" ]
       },
       "overrides": [],
       "dependencies": [],

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7681a3b089c7fd318822a420e990a3f1",
+  "checksum": "e54c3b8e11a4dd0d8922802b51e22921",
   "root": "reason-skia@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -781,7 +781,7 @@
         "@opam/conf-pkg-config@opam:1.1@67c69c0c",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9",
-        "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9"
+        "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/integers@opam:0.3.0@d6eefd3a",
@@ -1085,13 +1085,13 @@
       ],
       "devDependencies": []
     },
-    "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9": {
-      "id": "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9",
+    "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9": {
+      "id": "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9",
       "name": "@esy-ocaml/libffi",
-      "version": "github:glennsl/libffi#0d21ddb",
+      "version": "github:esy-ocaml/libffi#c61127d",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/libffi#0d21ddb" ]
+        "source": [ "github:esy-ocaml/libffi#c61127d" ]
       },
       "overrides": [],
       "dependencies": [],

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "3da3b96b99eb464e00f4f8c09846e419",
+  "checksum": "7681a3b089c7fd318822a420e990a3f1",
   "root": "reason-skia@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -781,7 +781,7 @@
         "@opam/conf-pkg-config@opam:1.1@67c69c0c",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9",
-        "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa@d41d8cd9"
+        "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/integers@opam:0.3.0@d6eefd3a",
@@ -1085,17 +1085,13 @@
       ],
       "devDependencies": []
     },
-    "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa@d41d8cd9": {
-      "id":
-        "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa@d41d8cd9",
+    "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9": {
+      "id": "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9",
       "name": "@esy-ocaml/libffi",
-      "version":
-        "github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa",
+      "version": "github:glennsl/libffi#0d21ddb",
       "source": {
         "type": "install",
-        "source": [
-          "github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa"
-        ]
+        "source": [ "github:glennsl/libffi#0d21ddb" ]
       },
       "overrides": [],
       "dependencies": [],

--- a/example-sdl.esy.lock/index.json
+++ b/example-sdl.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7681a3b089c7fd318822a420e990a3f1",
+  "checksum": "e54c3b8e11a4dd0d8922802b51e22921",
   "root": "reason-skia@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -781,7 +781,7 @@
         "@opam/conf-pkg-config@opam:1.1@67c69c0c",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9",
-        "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9"
+        "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/integers@opam:0.3.0@d6eefd3a",
@@ -1085,13 +1085,13 @@
       ],
       "devDependencies": []
     },
-    "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9": {
-      "id": "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9",
+    "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9": {
+      "id": "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9",
       "name": "@esy-ocaml/libffi",
-      "version": "github:glennsl/libffi#0d21ddb",
+      "version": "github:esy-ocaml/libffi#c61127d",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/libffi#0d21ddb" ]
+        "source": [ "github:esy-ocaml/libffi#c61127d" ]
       },
       "overrides": [],
       "dependencies": [],

--- a/example-sdl.esy.lock/index.json
+++ b/example-sdl.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "3da3b96b99eb464e00f4f8c09846e419",
+  "checksum": "7681a3b089c7fd318822a420e990a3f1",
   "root": "reason-skia@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -781,7 +781,7 @@
         "@opam/conf-pkg-config@opam:1.1@67c69c0c",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9",
-        "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa@d41d8cd9"
+        "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/integers@opam:0.3.0@d6eefd3a",
@@ -1085,17 +1085,13 @@
       ],
       "devDependencies": []
     },
-    "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa@d41d8cd9": {
-      "id":
-        "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa@d41d8cd9",
+    "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9": {
+      "id": "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9",
       "name": "@esy-ocaml/libffi",
-      "version":
-        "github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa",
+      "version": "github:glennsl/libffi#0d21ddb",
       "source": {
         "type": "install",
-        "source": [
-          "github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa"
-        ]
+        "source": [ "github:glennsl/libffi#0d21ddb" ]
       },
       "overrides": [],
       "dependencies": [],

--- a/example.esy.lock/index.json
+++ b/example.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7681a3b089c7fd318822a420e990a3f1",
+  "checksum": "e54c3b8e11a4dd0d8922802b51e22921",
   "root": "reason-skia@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -781,7 +781,7 @@
         "@opam/conf-pkg-config@opam:1.1@67c69c0c",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9",
-        "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9"
+        "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/integers@opam:0.3.0@d6eefd3a",
@@ -1085,13 +1085,13 @@
       ],
       "devDependencies": []
     },
-    "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9": {
-      "id": "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9",
+    "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9": {
+      "id": "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9",
       "name": "@esy-ocaml/libffi",
-      "version": "github:glennsl/libffi#0d21ddb",
+      "version": "github:esy-ocaml/libffi#c61127d",
       "source": {
         "type": "install",
-        "source": [ "github:glennsl/libffi#0d21ddb" ]
+        "source": [ "github:esy-ocaml/libffi#c61127d" ]
       },
       "overrides": [],
       "dependencies": [],

--- a/example.esy.lock/index.json
+++ b/example.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "3da3b96b99eb464e00f4f8c09846e419",
+  "checksum": "7681a3b089c7fd318822a420e990a3f1",
   "root": "reason-skia@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -781,7 +781,7 @@
         "@opam/conf-pkg-config@opam:1.1@67c69c0c",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9",
-        "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa@d41d8cd9"
+        "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/integers@opam:0.3.0@d6eefd3a",
@@ -1085,17 +1085,13 @@
       ],
       "devDependencies": []
     },
-    "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa@d41d8cd9": {
-      "id":
-        "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa@d41d8cd9",
+    "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9": {
+      "id": "@esy-ocaml/libffi@github:glennsl/libffi#0d21ddb@d41d8cd9",
       "name": "@esy-ocaml/libffi",
-      "version":
-        "github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa",
+      "version": "github:glennsl/libffi#0d21ddb",
       "source": {
         "type": "install",
-        "source": [
-          "github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa"
-        ]
+        "source": [ "github:glennsl/libffi#0d21ddb" ]
       },
       "overrides": [],
       "dependencies": [],

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ocaml": "~4.7.0"
   },
   "resolutions": {
-    "@esy-ocaml/libffi": "esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa",
+    "@esy-ocaml/libffi": "glennsl/libffi#0d21ddb",
     "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ocaml": "~4.7.0"
   },
   "resolutions": {
-    "@esy-ocaml/libffi": "glennsl/libffi#0d21ddb",
+    "@esy-ocaml/libffi": "esy-ocaml/libffi#c61127d",
     "esy-cmake": "prometheansacrifice/esy-cmake#2a47392def"
   }
 }

--- a/src/config/discover.re
+++ b/src/config/discover.re
@@ -49,12 +49,14 @@ let () = {
       @ cclib("-ljpeg")
       @ ccopt("-I/usr/include")
       @ ccopt("-lstdc++")
+
     | Windows =>
       []
       @ cclib("-lskia")
       @ cclib("-lSDL2")
       @ ccopt("-L" ++ Sys.getenv("SDL2_LIB_PATH"))
       @ ccopt("-L" ++ Sys.getenv("SKIA_LIB_PATH"))
+
     | _ => []
     };
 
@@ -65,6 +67,7 @@ let () = {
       @ ["-I" ++ Sys.getenv("SDL2_INCLUDE_PATH")]
       @ ["-I" ++ Sys.getenv("SKIA_INCLUDE_PATH")]
       @ ["-I" ++ Sys.getenv("SKIA_INCLUDE_PATH") ++ "/c"]
+
     | Linux =>
       []
       @ ["-lSDL2"]
@@ -77,12 +80,14 @@ let () = {
       @ ["-L" ++ Sys.getenv("JPEG_LIB_PATH")]
       @ ["-lstdc++"]
       @ ["-ljpeg"]
+
     | Windows =>
       []
       @ ["-std=c++1y"]
       @ ["-I" ++ Sys.getenv("SDL2_INCLUDE_PATH")]
       @ ["-I" ++ Sys.getenv("SKIA_INCLUDE_PATH")]
       @ ["-I" ++ Sys.getenv("SKIA_INCLUDE_PATH") ++ "/c"]
+
     | _ => failwith("cflags: unknown platform")
     };
 
@@ -102,6 +107,8 @@ let () = {
       @ ["-lskia"]
       @ ["-lstdc++"]
       @ [Sys.getenv("JPEG_LIB_PATH") ++ "/libturbojpeg.a"]
+      @ [Sys.getenv("FFI_LIB_PATH") ++ "/libffi.a"]
+
     | Linux =>
       []
       @ [
@@ -119,6 +126,7 @@ let () = {
         "-L" ++ Sys.getenv("SKIA_LIB_PATH"),
         "-L" ++ Sys.getenv("FREETYPE2_LIB_PATH"),
       ]
+
     | Windows =>
       []
       @ ["-luser32"]
@@ -127,6 +135,7 @@ let () = {
       @ ["-lstdc++"]
       @ ["-L" ++ Sys.getenv("SDL2_LIB_PATH")]
       @ ["-L" ++ Sys.getenv("SKIA_LIB_PATH")]
+
     | _ => failwith("libs: Unknown platform")
     };
 

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "f012ce9f850bd6d127ab11cf3c05721d",
+  "checksum": "f162740e583abc040b54e889ce534327",
   "root": "reason-skia@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -1040,7 +1040,7 @@
         "@opam/conf-pkg-config@opam:1.1@67c69c0c",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9",
-        "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa@d41d8cd9"
+        "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/integers@opam:0.3.0@d6eefd3a",
@@ -1372,17 +1372,13 @@
       ],
       "devDependencies": []
     },
-    "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa@d41d8cd9": {
-      "id":
-        "@esy-ocaml/libffi@github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa@d41d8cd9",
+    "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9": {
+      "id": "@esy-ocaml/libffi@github:esy-ocaml/libffi#c61127d@d41d8cd9",
       "name": "@esy-ocaml/libffi",
-      "version":
-        "github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa",
+      "version": "github:esy-ocaml/libffi#c61127d",
       "source": {
         "type": "install",
-        "source": [
-          "github:esy-ocaml/libffi#599bc3567ecf839240977b6d9aaf0b80f983b5aa"
-        ]
+        "source": [ "github:esy-ocaml/libffi#c61127d" ]
       },
       "overrides": [],
       "dependencies": [],

--- a/update-lockfiles.sh
+++ b/update-lockfiles.sh
@@ -1,4 +1,5 @@
 esy install
+esy '@test' install
 esy '@bench' install
 esy '@example' install
 esy '@example-sdl' install


### PR DESCRIPTION
In order to fix the macOS Ci build failure in https://github.com/onivim/oni2/pull/801

Depends on
- [x] https://github.com/esy-ocaml/libffi/pull/3