### PR TITLE
Perf: Rect - speed up get* methods with raw bindings

### DIFF
--- a/bench/lib/RectBench.re
+++ b/bench/lib/RectBench.re
@@ -19,6 +19,13 @@ let makeLtrb = () => {
   ();
 };
 
+let getLeft = () => {
+  let _: float = Skia.Rect.getLeft(Data.initialRect);
+  ();
+};
+
 bench(~name="Rect: makeLtrb", ~options, ~setup=() => (), ~f=makeLtrb, ());
 
 bench(~name="Rect: setLtrb", ~options, ~setup=() => (), ~f=setLtrb, ());
+
+bench(~name="Rect: getLeft", ~options, ~setup=() => (), ~f=getLeft, ());

--- a/src/Skia.re
+++ b/src/Skia.re
@@ -270,10 +270,9 @@ module IRect = {
 
 module Rect = {
   type t = SkiaWrapped.Rect.t;
+  module CI = Cstubs_internals;
 
   module Mutable = {
-    module CI = Cstubs_internals;
-
     [@noalloc]
     external _set:
       (
@@ -290,12 +289,29 @@ module Rect = {
       _set(CI.cptr(out), left, top, right, bottom);
   };
 
+  [@noalloc]
+  external _getLeft: CI.fatptr(_) => [@unboxed] float =
+    "reason_skia_rect_get_left_byte" "reason_skia_rect_get_left";
+
+  [@noalloc]
+  external _getTop: CI.fatptr(_) => [@unboxed] float =
+    "reason_skia_rect_get_top_byte" "reason_skia_rect_get_top";
+
+  [@noalloc]
+  external _getRight: CI.fatptr(_) => [@unboxed] float =
+    "reason_skia_rect_get_right_byte" "reason_skia_rect_get_right";
+
+  [@noalloc]
+  external _getBottom: CI.fatptr(_) => [@unboxed] float =
+    "reason_skia_rect_get_bottom_byte" "reason_skia_rect_get_bottom";
+
+  let getLeft = rect => _getLeft(CI.cptr(rect));
+  let getTop = rect => _getTop(CI.cptr(rect));
+  let getBottom = rect => _getBottom(CI.cptr(rect));
+  let getRight = rect => _getRight(CI.cptr(rect));
+
   let makeEmpty = SkiaWrapped.Rect.makeEmpty;
   let makeLtrb = SkiaWrapped.Rect.makeLtrb;
-  let getLeft = SkiaWrapped.Rect.getLeft;
-  let getTop = SkiaWrapped.Rect.getTop;
-  let getRight = SkiaWrapped.Rect.getRight;
-  let getBottom = SkiaWrapped.Rect.getBottom;
 
   let toString = rect => {
     let left = getLeft(rect);

--- a/src/wrapped/lib/raw_bindings.c
+++ b/src/wrapped/lib/raw_bindings.c
@@ -15,6 +15,58 @@
 
 #include "ctypes_cstubs_internals.h"
 
+double reason_skia_rect_get_bottom(
+   value vRect
+) {
+   sk_rect_t *pRect = CTYPES_ADDR_OF_FATPTR(vRect);
+   return (double)pRect->bottom;
+}
+
+CAMLprim value reason_skia_rect_get_bottom_byte(
+   value vRect
+) {
+   return caml_copy_double(reason_skia_rect_get_bottom(vRect));
+}
+
+double reason_skia_rect_get_right(
+   value vRect
+) {
+   sk_rect_t *pRect = CTYPES_ADDR_OF_FATPTR(vRect);
+   return (double)pRect->right;
+}
+
+CAMLprim value reason_skia_rect_get_right_byte(
+   value vRect
+) {
+   return caml_copy_double(reason_skia_rect_get_right(vRect));
+}
+
+double reason_skia_rect_get_top(
+   value vRect
+) {
+   sk_rect_t *pRect = CTYPES_ADDR_OF_FATPTR(vRect);
+   return (double)pRect->top;
+}
+
+CAMLprim value reason_skia_rect_get_top_byte(
+   value vRect
+) {
+   return caml_copy_double(reason_skia_rect_get_top(vRect));
+}
+
+double reason_skia_rect_get_left(
+   value vRect
+) {
+   sk_rect_t *pRect = CTYPES_ADDR_OF_FATPTR(vRect);
+   return (double)pRect->left;
+}
+
+CAMLprim value reason_skia_rect_get_left_byte(
+   value vRect
+) {
+   return caml_copy_double(reason_skia_rect_get_left(vRect));
+}
+
 CAMLprim value reason_skia_rect_set(
    value vRect,
    double left,


### PR DESCRIPTION
Benchmark __before:__
```
|------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
|  Rect: getLeft         |  100000     |  0.00241208076477   |  11        |  0         |  2800143      |  65        |  65           |
|------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
```

__After:__
```
|------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
|  Rect: getLeft         |  100000     |  0.000338077545166  |  1         |  0         |  200029       |  25        |  25           |
|------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
```

Significant improvement in the timing - not quite, but almost, an order of magnitude faster with `[@noalloc]` and `[@unboxed]`