### PR TITLE
Perf: Color API improvements

### DIFF
--- a/bench/lib/ColorBench.re
+++ b/bench/lib/ColorBench.re
@@ -23,11 +23,23 @@ let getA = () => {
   ();
 };
 
+let getAFloat = () => {
+  let _: float = Skia.Color.Float.getA(Data.initialColor);
+  ();
+};
+
 bench(
   ~name="Color: makeArgb (float)",
   ~options,
   ~setup=() => (),
   ~f=makeArgbFloat,
+  (),
+);
+bench(
+  ~name="Color: getA (float)",
+  ~options,
+  ~setup=() => (),
+  ~f=getAFloat,
   (),
 );
 bench(~name="Color: makeArgb", ~options, ~setup=() => (), ~f=makeArgb, ());

--- a/bench/lib/ColorBench.re
+++ b/bench/lib/ColorBench.re
@@ -1,0 +1,23 @@
+open BenchFramework;
+
+open Skia;
+
+let options = Reperf.Options.create(~iterations=100000, ());
+
+module Data = {
+  let initialColor = Skia.Color.makeArgb(0xFF, 0xFF, 0xFF, 0xFF);
+};
+
+let makeArgb = () => {
+  let _: Skia.Color.t =
+    Skia.Color.makeArgb(0xFF, 0xFF, 0xFF, 0xFF)
+};
+
+let getA = () => {
+  let _: int =
+    Skia.Color.getA(Data.initialColor);
+};
+
+bench(~name="Color: makeArgb", ~options, ~setup=() => (), ~f=makeArgb, ());
+bench(~name="Color: getA", ~options, ~setup=() => (), ~f=makeArgb, ());
+

--- a/bench/lib/ColorBench.re
+++ b/bench/lib/ColorBench.re
@@ -13,10 +13,22 @@ let makeArgb = () => {
   ();
 };
 
+let makeArgbFloat = () => {
+  let _: Skia.Color.t = Skia.Color.Float.makeArgb(0.1, 0.2, 0.3, 0.4);
+  ();
+};
+
 let getA = () => {
   let _: int32 = Skia.Color.getA(Data.initialColor);
   ();
 };
 
+bench(
+  ~name="Color: makeArgb (float)",
+  ~options,
+  ~setup=() => (),
+  ~f=makeArgbFloat,
+  (),
+);
 bench(~name="Color: makeArgb", ~options, ~setup=() => (), ~f=makeArgb, ());
 bench(~name="Color: getA", ~options, ~setup=() => (), ~f=makeArgb, ());

--- a/bench/lib/ColorBench.re
+++ b/bench/lib/ColorBench.re
@@ -5,19 +5,18 @@ open Skia;
 let options = Reperf.Options.create(~iterations=100000, ());
 
 module Data = {
-  let initialColor = Skia.Color.makeArgb(0xFF, 0xFF, 0xFF, 0xFF);
+  let initialColor = Skia.Color.makeArgb(0xFFl, 0xFFl, 0xFFl, 0xFFl);
 };
 
 let makeArgb = () => {
-  let _: Skia.Color.t =
-    Skia.Color.makeArgb(0xFF, 0xFF, 0xFF, 0xFF)
+  let _: Skia.Color.t = Skia.Color.makeArgb(0xFFl, 0xFFl, 0xFFl, 0xFFl);
+  ();
 };
 
 let getA = () => {
-  let _: int =
-    Skia.Color.getA(Data.initialColor);
+  let _: int32 = Skia.Color.getA(Data.initialColor);
+  ();
 };
 
 bench(~name="Color: makeArgb", ~options, ~setup=() => (), ~f=makeArgb, ());
 bench(~name="Color: getA", ~options, ~setup=() => (), ~f=makeArgb, ());
-

--- a/bench/lib/PaintBench.re
+++ b/bench/lib/PaintBench.re
@@ -6,7 +6,7 @@ let options = Reperf.Options.create(~iterations=100000, ());
 
 module Data = {
   let initialPaint = Paint.make();
-  let initialColor = Color.makeArgb(0xFF, 0xFF, 0xFF, 0xFF);
+  let initialColor = Color.makeArgb(0xFFl, 0xFFl, 0xFFl, 0xFFl);
 };
 
 let make = () => {

--- a/example-sdl/TestSdl.re
+++ b/example-sdl/TestSdl.re
@@ -98,10 +98,16 @@ let run = () => {
     ignore(context);
     ignore(surface);
 
-    Skia.Canvas.clear(canvas, Skia.Color.makeArgb(0xFF, 0xFF, 0x00, 0x00));
+    Skia.Canvas.clear(
+      canvas,
+      Skia.Color.makeArgb(0xFFl, 0xFFl, 0x00l, 0x00l),
+    );
 
     let paint = Skia.Paint.make();
-    Skia.Paint.setColor(paint, Skia.Color.makeArgb(0xFF, 0xFF, 0xFF, 0xFF));
+    Skia.Paint.setColor(
+      paint,
+      Skia.Color.makeArgb(0xFFl, 0xFFl, 0xFFl, 0xFFl),
+    );
 
     Skia.Canvas.drawText(canvas, "Hello, world!", 50., 50., paint);
 

--- a/example/TestApp.re
+++ b/example/TestApp.re
@@ -16,15 +16,15 @@ let emitPng = (path, surface) => {
 
 let draw = canvas => {
   let fill = Paint.make();
-  Paint.setColor(fill, Color.makeArgb(0xFF, 0x00, 0x00, 0xFF));
+  Paint.setColor(fill, Color.makeArgb(0xFFl, 0x00l, 0x00l, 0xFFl));
   Canvas.drawPaint(canvas, fill);
 
-  Paint.setColor(fill, Color.makeArgb(0xFF, 0x00, 0xFF, 0xFF));
+  Paint.setColor(fill, Color.makeArgb(0xFFl, 0x00l, 0xFFl, 0xFFl));
   let rect = Rect.makeLtrb(100., 100., 540., 380.);
   Canvas.drawRect(canvas, rect, fill);
 
   let stroke = Paint.make();
-  Paint.setColor(stroke, Color.makeArgb(0xFF, 0xFF, 0x00, 0x00));
+  Paint.setColor(stroke, Color.makeArgb(0xFFl, 0xFFl, 0x00l, 0x00l));
   Paint.setAntiAlias(stroke, true);
   Paint.setStyle(stroke, Stroke);
   Paint.setStrokeWidth(stroke, 5.);
@@ -36,7 +36,7 @@ let draw = canvas => {
   Path.lineTo(path, 590., 430.);
   Canvas.drawPath(canvas, path, stroke);
 
-  Paint.setColor(fill, Color.makeArgb(0xCC, 0x00, 0xFF, 0x00));
+  Paint.setColor(fill, Color.makeArgb(0xCCl, 0x00l, 0xFFl, 0x00l));
   Paint.setImageFilter(
     fill,
     ImageFilter.makeDropShadow(
@@ -44,7 +44,7 @@ let draw = canvas => {
       10.,
       3.,
       3.,
-      Color.makeArgb(0xAA, 0x00, 0x00, 0x00),
+      Color.makeArgb(0xAAl, 0x00l, 0x00l, 0x00l),
       DrawShadowAndForeground,
       None,
       None,
@@ -54,7 +54,7 @@ let draw = canvas => {
   Canvas.drawOval(canvas, rect2, fill);
 
   let fill3 = Paint.make();
-  Paint.setColor(fill3, Color.makeArgb(0xFF, 0xFF, 0xFF, 0xFF));
+  Paint.setColor(fill3, Color.makeArgb(0xFFl, 0xFFl, 0xFFl, 0xFFl));
   Paint.setTextSize(fill3, 30.);
 
   let nonExistentTypeface = Typeface.makeFromFile("non-existent-font.ttf", 0);
@@ -127,7 +127,7 @@ let draw = canvas => {
   | None => failwith("Unable to load font: " ++ filePath)
   | Some(typeFace) =>
     let fill = Paint.make();
-    Paint.setColor(fill, Color.makeArgb(0xFF, 0xFF, 0xFF, 0xFF));
+    Paint.setColor(fill, Color.makeArgb(0xFFl, 0xFFl, 0xFFl, 0xFFl));
     Paint.setTextSize(fill, 30.);
     Paint.setTypeface(fill, typeFace);
     Paint.setSubpixelText(fill, true);
@@ -160,7 +160,7 @@ let draw = canvas => {
   };
 
   let fill = Paint.make();
-  Paint.setColor(fill, Color.makeArgb(0xFF, 0xFF, 0x00, 0xFF));
+  Paint.setColor(fill, Color.makeArgb(0xFFl, 0xFFl, 0x00l, 0xFFl));
   Canvas.drawRectLtwh(canvas, 50., 75., 100., 200., fill);
 };
 

--- a/src/Skia.re
+++ b/src/Skia.re
@@ -25,6 +25,19 @@ module Color = {
   [@noalloc]
   external getB: ([@unboxed] int32) => [@unboxed] int32 =
     "reason_skia_stub_sk_color_get_b_byte" "reason_skia_stub_sk_color_get_b";
+
+  module Float = {
+    external makeArgb:
+      (
+        [@unboxed] float,
+        [@unboxed] float,
+        [@unboxed] float,
+        [@unboxed] float
+      ) =>
+      [@unboxed] int32 =
+      "reason_skia_color_float_make_argb_byte"
+      "reason_skia_color_float_make_argb";
+  };
 };
 
 module FontMetrics = {

--- a/src/Skia.re
+++ b/src/Skia.re
@@ -116,6 +116,8 @@ module Paint = {
   type t = SkiaWrapped.Paint.t;
   type style = SkiaWrapped.Paint.style;
 
+  module CI = Cstubs_internals;
+
   let make = () => {
     let paint = SkiaWrapped.Paint.allocate();
     Gc.finalise(SkiaWrapped.Paint.delete, paint);
@@ -126,9 +128,12 @@ module Paint = {
     SkiaWrapped.Paint.measureText(paint, text, String.length(text), rectOpt);
   };
 
-  // TODO: Make fast
-  let setColor = (paint, color) =>
-    SkiaWrapped.Paint.setColor(paint, Unsigned.UInt32.of_int32(color));
+  [@noalloc]
+  external _setColor: (CI.fatptr(_), [@unboxed] int32) => unit =
+    "reason_skia_paint_set_color_byte" "reason_skia_paint_set_color";
+
+  let setColor = (paint, color) => _setColor(CI.cptr(paint), color);
+
   let setAntiAlias = SkiaWrapped.Paint.setAntiAlias;
   let setStyle = SkiaWrapped.Paint.setStyle;
   let setStrokeWidth = SkiaWrapped.Paint.setStrokeWidth;

--- a/src/Skia.re
+++ b/src/Skia.re
@@ -2,13 +2,29 @@ type colorType = SkiaWrapped.colorType;
 type alphaType = SkiaWrapped.alphaType;
 
 module Color = {
-  type t = SkiaWrapped.Color.t;
+  type t = int32;
+  [@noalloc]
+  external makeArgb:
+    ([@unboxed] int32, [@unboxed] int32, [@unboxed] int32, [@unboxed] int32) =>
+    [@unboxed] int32 =
+    "reason_skia_stub_sk_color_set_argb_byte"
+    "reason_skia_stub_sk_color_set_argb";
 
-  let makeArgb = SkiaWrapped.Color.makeArgb;
-  let getA = SkiaWrapped.Color.getA;
-  let getR = SkiaWrapped.Color.getR;
-  let getG = SkiaWrapped.Color.getG;
-  let getB = SkiaWrapped.Color.getB;
+  [@noalloc]
+  external getA: ([@unboxed] int32) => [@unboxed] int32 =
+    "reason_skia_stub_sk_color_get_a_byte" "reason_skia_stub_sk_color_get_a";
+
+  [@noalloc]
+  external getR: ([@unboxed] int32) => [@unboxed] int32 =
+    "reason_skia_stub_sk_color_get_r_byte" "reason_skia_stub_sk_color_get_r";
+
+  [@noalloc]
+  external getG: ([@unboxed] int32) => [@unboxed] int32 =
+    "reason_skia_stub_sk_color_get_g_byte" "reason_skia_stub_sk_color_get_g";
+
+  [@noalloc]
+  external getB: ([@unboxed] int32) => [@unboxed] int32 =
+    "reason_skia_stub_sk_color_get_b_byte" "reason_skia_stub_sk_color_get_b";
 };
 
 module FontMetrics = {
@@ -52,7 +68,8 @@ module ImageFilter = {
           dy,
           sigmaX,
           sigmaY,
-          color,
+          // TODO: Make fast
+          Unsigned.UInt32.of_int32(color),
           shadowMode,
           inputOption,
           cropRectOption,
@@ -79,7 +96,9 @@ module Paint = {
     SkiaWrapped.Paint.measureText(paint, text, String.length(text), rectOpt);
   };
 
-  let setColor = SkiaWrapped.Paint.setColor;
+  // TODO: Make fast
+  let setColor = (paint, color) =>
+    SkiaWrapped.Paint.setColor(paint, Unsigned.UInt32.of_int32(color));
   let setAntiAlias = SkiaWrapped.Paint.setAntiAlias;
   let setStyle = SkiaWrapped.Paint.setStyle;
   let setStrokeWidth = SkiaWrapped.Paint.setStrokeWidth;
@@ -503,7 +522,9 @@ module Canvas = {
       Ctypes.structure(SkiaWrappedBindings.SkiaTypes.Canvas.t),
     );
 
-  let clear = SkiaWrapped.Canvas.clear;
+  // TODO: Make fast
+  let clear = (canvas, color) =>
+    SkiaWrapped.Canvas.clear(canvas, Unsigned.UInt32.of_int32(color));
 
   let drawPaint = SkiaWrapped.Canvas.drawPaint;
   let drawRect = SkiaWrapped.Canvas.drawRect;

--- a/src/Skia.re
+++ b/src/Skia.re
@@ -37,6 +37,23 @@ module Color = {
       [@unboxed] int32 =
       "reason_skia_color_float_make_argb_byte"
       "reason_skia_color_float_make_argb";
+
+    [@noalloc]
+    external getA: ([@unboxed] int32) => [@unboxed] float =
+      "reason_skia_stub_sk_color_float_get_a_byte"
+      "reason_skia_stub_sk_color_float_get_a";
+
+    external getR: ([@unboxed] int32) => [@unboxed] float =
+      "reason_skia_stub_sk_color_float_get_r_byte"
+      "reason_skia_stub_sk_color_float_get_r";
+
+    external getG: ([@unboxed] int32) => [@unboxed] float =
+      "reason_skia_stub_sk_color_float_get_g_byte"
+      "reason_skia_stub_sk_color_float_get_g";
+
+    external getB: ([@unboxed] int32) => [@unboxed] float =
+      "reason_skia_stub_sk_color_float_get_b_byte"
+      "reason_skia_stub_sk_color_float_get_b";
   };
 };
 

--- a/src/Skia.re
+++ b/src/Skia.re
@@ -5,6 +5,10 @@ module Color = {
   type t = SkiaWrapped.Color.t;
 
   let makeArgb = SkiaWrapped.Color.makeArgb;
+  let getA = SkiaWrapped.Color.getA;
+  let getR = SkiaWrapped.Color.getR;
+  let getG = SkiaWrapped.Color.getG;
+  let getB = SkiaWrapped.Color.getB;
 };
 
 module FontMetrics = {

--- a/src/Skia.rei
+++ b/src/Skia.rei
@@ -10,7 +10,13 @@ module Color: {
   let getG: t => int32;
   let getB: t => int32;
 
-  module Float: {let makeArgb: (float, float, float, float) => t;};
+  module Float: {
+    let makeArgb: (float, float, float, float) => t;
+    let getA: t => float;
+    let getR: t => float;
+    let getG: t => float;
+    let getB: t => float;
+  };
 };
 
 module FontStyle: {

--- a/src/Skia.rei
+++ b/src/Skia.rei
@@ -5,6 +5,10 @@ module Color: {
   type t;
 
   let makeArgb: (int, int, int, int) => t;
+  let getA: t => int;
+  let getR: t => int;
+  let getG: t => int;
+  let getB: t => int;
 };
 
 module FontStyle: {

--- a/src/Skia.rei
+++ b/src/Skia.rei
@@ -2,13 +2,13 @@ type colorType = SkiaWrapped.colorType;
 type alphaType = SkiaWrapped.alphaType;
 
 module Color: {
-  type t;
+  type t = int32;
 
-  let makeArgb: (int, int, int, int) => t;
-  let getA: t => int;
-  let getR: t => int;
-  let getG: t => int;
-  let getB: t => int;
+  let makeArgb: (int32, int32, int32, int32) => t;
+  let getA: t => int32;
+  let getR: t => int32;
+  let getG: t => int32;
+  let getB: t => int32;
 };
 
 module FontStyle: {

--- a/src/Skia.rei
+++ b/src/Skia.rei
@@ -9,6 +9,8 @@ module Color: {
   let getR: t => int32;
   let getG: t => int32;
   let getB: t => int32;
+
+  module Float: {let makeArgb: (float, float, float, float) => t;};
 };
 
 module FontStyle: {

--- a/src/wrapped/bindings/SkiaWrappedBindings.re
+++ b/src/wrapped/bindings/SkiaWrappedBindings.re
@@ -27,6 +27,26 @@ module M = (F: FOREIGN) => {
         "reason_skia_stub_sk_color_set_argb",
         int @-> int @-> int @-> int @-> returning(uint32_t),
       );
+
+    let getA = foreign(
+      "reason_skia_stub_sk_color_get_a",
+      uint32_t @-> returning(int)
+    );
+
+    let getR = foreign(
+      "reason_skia_stub_sk_color_get_r",
+      uint32_t @-> returning(int)
+    );
+    
+    let getG = foreign(
+      "reason_skia_stub_sk_color_get_g",
+      uint32_t @-> returning(int)
+    );
+
+    let getB = foreign(
+      "reason_skia_stub_sk_color_get_b",
+      uint32_t @-> returning(int)
+    );
   };
 
   module FontStyle = {

--- a/src/wrapped/bindings/SkiaWrappedBindings.re
+++ b/src/wrapped/bindings/SkiaWrappedBindings.re
@@ -21,32 +21,6 @@ module M = (F: FOREIGN) => {
   module Color = {
     type t = Unsigned.uint32;
     let t = uint32_t;
-
-    let makeArgb =
-      foreign(
-        "reason_skia_stub_sk_color_set_argb",
-        int @-> int @-> int @-> int @-> returning(uint32_t),
-      );
-
-    let getA = foreign(
-      "reason_skia_stub_sk_color_get_a",
-      uint32_t @-> returning(int)
-    );
-
-    let getR = foreign(
-      "reason_skia_stub_sk_color_get_r",
-      uint32_t @-> returning(int)
-    );
-    
-    let getG = foreign(
-      "reason_skia_stub_sk_color_get_g",
-      uint32_t @-> returning(int)
-    );
-
-    let getB = foreign(
-      "reason_skia_stub_sk_color_get_b",
-      uint32_t @-> returning(int)
-    );
   };
 
   module FontStyle = {

--- a/src/wrapped/c/c_stubs.c
+++ b/src/wrapped/c/c_stubs.c
@@ -7,32 +7,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-
-sk_color_t reason_skia_stub_sk_color_set_argb(int alpha, int red, int green, int blue)
-{
-    return sk_color_set_argb(alpha, red, green, blue);
-}
-
-uint32_t reason_skia_stub_sk_color_get_a(sk_color_t color)
-{
-    return sk_color_get_a(color);
-}
-
-uint32_t reason_skia_stub_sk_color_get_r(sk_color_t color)
-{
-    return sk_color_get_r(color);
-}
-
-uint32_t reason_skia_stub_sk_color_get_g(sk_color_t color)
-{
-    return sk_color_get_g(color);
-}
-
-uint32_t reason_skia_stub_sk_color_get_b(sk_color_t color)
-{
-    return sk_color_get_b(color);
-}
-
 void reason_skia_stub_sk_canvas_draw_rect_ltwh(
 sk_canvas_t *canvas, float left, float top, float width, float height, sk_paint_t *paint) 
 {

--- a/src/wrapped/c/c_stubs.h
+++ b/src/wrapped/c/c_stubs.h
@@ -5,13 +5,6 @@
 
 #include <SDL2/SDL.h>
 
-sk_color_t reason_skia_stub_sk_color_set_argb(int alpha, int red, int green, int blue);
-
-uint32_t reason_skia_stub_sk_color_get_a(sk_color_t color);
-uint32_t reason_skia_stub_sk_color_get_r(sk_color_t color);
-uint32_t reason_skia_stub_sk_color_get_g(sk_color_t color);
-uint32_t reason_skia_stub_sk_color_get_b(sk_color_t color);
-
 void reason_skia_stub_sk_canvas_draw_rect_ltwh(sk_canvas_t *canvas, float left, float top, float width, float height, sk_paint_t* paint);
 
 gr_glinterface_t* reason_skia_make_sdl2_interface();

--- a/src/wrapped/lib/raw_bindings.c
+++ b/src/wrapped/lib/raw_bindings.c
@@ -15,6 +15,23 @@
 
 #include "ctypes_cstubs_internals.h"
 
+CAMLprim value reason_skia_paint_set_color(
+value vPaint,
+int32_t color
+) {
+   sk_paint_t* pPaint = CTYPES_ADDR_OF_FATPTR(vPaint);
+   sk_paint_set_color(pPaint, color);
+   return Val_unit;
+}
+
+CAMLprim value reason_skia_matrix_set_color_byte(
+	value vPaint,
+	value vColor) {
+	return reason_skia_paint_set_color(
+      vPaint,
+      Int_val(vColor));
+}
+
 double reason_skia_stub_sk_color_float_get_b(int32_t color) {
     return (double)(sk_color_get_b(color) / 255.0);
 }

--- a/src/wrapped/lib/raw_bindings.c
+++ b/src/wrapped/lib/raw_bindings.c
@@ -15,6 +15,70 @@
 
 #include "ctypes_cstubs_internals.h"
 
+uint32_t reason_skia_stub_sk_color_get_a(int32_t color) {
+    return (uint32_t)sk_color_get_a(color);
+}
+
+CAMLprim value reason_skia_stub_sk_color_get_a_byte(value vColor) {
+   return Val_int(reason_skia_stub_sk_color_get_a(
+       Int_val(vColor)
+   ));
+}
+
+uint32_t reason_skia_stub_sk_color_get_r(int32_t color) {
+    return (uint32_t)sk_color_get_r(color);
+}
+
+CAMLprim value reason_skia_stub_sk_color_get_r_byte(value vColor) {
+   return Val_int(reason_skia_stub_sk_color_get_r(
+       Int_val(vColor)
+   ));
+}
+
+uint32_t reason_skia_stub_sk_color_get_g(int32_t color) {
+    return (uint32_t)sk_color_get_g(color);
+}
+
+CAMLprim value reason_skia_stub_sk_color_get_g_byte(value vColor) {
+   return Val_int(reason_skia_stub_sk_color_get_g(
+       Int_val(vColor)
+   ));
+}
+
+uint32_t reason_skia_stub_sk_color_get_b(int32_t color) {
+    return (uint32_t)sk_color_get_b(color);
+}
+
+
+CAMLprim value reason_skia_stub_sk_color_get_b_byte(value vColor) {
+   return Val_int(reason_skia_stub_sk_color_get_b(
+       Int_val(vColor)
+   ));
+}
+
+uint32_t reason_skia_stub_sk_color_set_argb(
+   int32_t alpha, 
+   int32_t red, 
+   int32_t green, 
+   int32_t blue)
+{
+    return (uint32_t)sk_color_set_argb(alpha, red, green, blue);
+}
+
+CAMLprim value reason_skia_stub_sk_color_set_argb_byte(
+   value vAlpha,
+   value vRed,
+   value vGreen,
+   value vBlue
+) {
+   return Val_int(reason_skia_stub_sk_color_set_argb(
+       Int_val(vAlpha),
+       Int_val(vRed),
+       Int_val(vGreen),
+       Int_val(vBlue)
+   ));
+}
+
 double reason_skia_rect_get_bottom(
    value vRect
 ) {

--- a/src/wrapped/lib/raw_bindings.c
+++ b/src/wrapped/lib/raw_bindings.c
@@ -15,6 +15,46 @@
 
 #include "ctypes_cstubs_internals.h"
 
+double reason_skia_stub_sk_color_float_get_b(int32_t color) {
+    return (double)(sk_color_get_b(color) / 255.0);
+}
+
+CAMLprim value reason_skia_stub_sk_color_float_get_b_byte(value vColor) {
+   return caml_copy_double(reason_skia_stub_sk_color_float_get_b(
+       Int_val(vColor)
+   ));
+}
+
+double reason_skia_stub_sk_color_float_get_g(int32_t color) {
+    return (double)(sk_color_get_g(color) / 255.0);
+}
+
+CAMLprim value reason_skia_stub_sk_color_float_get_g_byte(value vColor) {
+   return caml_copy_double(reason_skia_stub_sk_color_float_get_g(
+       Int_val(vColor)
+   ));
+}
+
+double reason_skia_stub_sk_color_float_get_r(int32_t color) {
+    return (double)(sk_color_get_r(color) / 255.0);
+}
+
+CAMLprim value reason_skia_stub_sk_color_float_get_r_byte(value vColor) {
+   return caml_copy_double(reason_skia_stub_sk_color_float_get_r(
+       Int_val(vColor)
+   ));
+}
+
+double reason_skia_stub_sk_color_float_get_a(int32_t color) {
+    return (double)(sk_color_get_a(color) / 255.0);
+}
+
+CAMLprim value reason_skia_stub_sk_color_float_get_a_byte(value vColor) {
+   return caml_copy_double(reason_skia_stub_sk_color_float_get_a(
+       Int_val(vColor)
+   ));
+}
+
 uint32_t reason_skia_color_float_make_argb(
 double a,
 double r,

--- a/src/wrapped/lib/raw_bindings.c
+++ b/src/wrapped/lib/raw_bindings.c
@@ -15,6 +15,30 @@
 
 #include "ctypes_cstubs_internals.h"
 
+uint32_t reason_skia_color_float_make_argb(
+double a,
+double r,
+double g,
+double b) {
+   int iA = (int)(255.0 * a);
+   int iR = (int)(255.0 * r);
+   int iG = (int)(255.0 * g);
+   int iB = (int)(255.0 * b);
+   return (uint32_t)sk_color_set_argb(iA, iR, iG, iB);
+}
+
+CAMLprim value reason_skia_color_float_make_argb_byte(
+	value vA,
+	value vR,
+	value vG,
+	value vB) {
+	return Val_int(reason_skia_color_float_make_argb(
+	Double_val(vA),
+	Double_val(vR),
+	Double_val(vG),
+	Double_val(vB)));
+}
+
 uint32_t reason_skia_stub_sk_color_get_a(int32_t color) {
     return (uint32_t)sk_color_get_a(color);
 }

--- a/test/ColorTest.re
+++ b/test/ColorTest.re
@@ -3,16 +3,16 @@ open TestFramework;
 
 describe("Color", ({test, _}) => {
   test("makeArgb", ({expect}) => {
-    let color = Color.makeArgb(0x1A, 0x1B, 0x1C, 0x1D);
+    let color = Color.makeArgb(0x1Al, 0x1Bl, 0x1Cl, 0x1Dl);
 
-    let a = Color.getA(color);
-    let r = Color.getR(color);
-    let g = Color.getG(color);
-    let b = Color.getB(color);
+    let a = Color.getA(color) |> Int32.to_int;
+    let r = Color.getR(color) |> Int32.to_int;
+    let g = Color.getG(color) |> Int32.to_int;
+    let b = Color.getB(color) |> Int32.to_int;
 
     expect.int(a).toBe(0x1A);
     expect.int(r).toBe(0x1B);
     expect.int(g).toBe(0x1C);
     expect.int(b).toBe(0x1D);
-  });
+  })
 });

--- a/test/ColorTest.re
+++ b/test/ColorTest.re
@@ -1,7 +1,22 @@
 open Skia;
 open TestFramework;
 
-describe("Color", ({test, _}) => {
+describe("Color", ({describe, test}) => {
+  describe("float", ({test}) => {
+    test("makeArgb", ({expect}) => {
+      let color = Color.Float.makeArgb(0., 0.25099, 0.501961, 1.0);
+
+      let a = Color.getA(color) |> Int32.to_int;
+      let r = Color.getR(color) |> Int32.to_int;
+      let g = Color.getG(color) |> Int32.to_int;
+      let b = Color.getB(color) |> Int32.to_int;
+
+      expect.int(a).toBe(0x00);
+      expect.int(r).toBe(0x40);
+      expect.int(g).toBe(0x80);
+      expect.int(b).toBe(0xFF);
+    })
+  });
   test("makeArgb", ({expect}) => {
     let color = Color.makeArgb(0x1Al, 0x1Bl, 0x1Cl, 0x1Dl);
 
@@ -14,5 +29,5 @@ describe("Color", ({test, _}) => {
     expect.int(r).toBe(0x1B);
     expect.int(g).toBe(0x1C);
     expect.int(b).toBe(0x1D);
-  })
+  });
 });

--- a/test/ColorTest.re
+++ b/test/ColorTest.re
@@ -1,0 +1,18 @@
+open Skia;
+open TestFramework;
+
+describe("Color", ({test, _}) => {
+  test("makeArgb", ({expect}) => {
+    let color = Color.makeArgb(0x1A, 0x1B, 0x1C, 0x1D);
+
+    let a = Color.getA(color);
+    let r = Color.getR(color);
+    let g = Color.getG(color);
+    let b = Color.getB(color);
+
+    expect.int(a).toBe(0x1A);
+    expect.int(r).toBe(0x1B);
+    expect.int(g).toBe(0x1C);
+    expect.int(b).toBe(0x1D);
+  });
+});

--- a/test/ColorTest.re
+++ b/test/ColorTest.re
@@ -15,7 +15,21 @@ describe("Color", ({describe, test}) => {
       expect.int(r).toBe(0x40);
       expect.int(g).toBe(0x80);
       expect.int(b).toBe(0xFF);
-    })
+    });
+
+    test("getA/R/G/B", ({expect}) => {
+      let color = Color.Float.makeArgb(1.0, 0.501961, 0.25099, 0.);
+
+      let a = Color.Float.getA(color);
+      let r = Color.Float.getR(color);
+      let g = Color.Float.getG(color);
+      let b = Color.Float.getB(color);
+
+      expect.float(a).toBeCloseTo(1.0);
+      expect.float(r).toBeCloseTo(0.501961);
+      expect.float(g).toBeCloseTo(0.25099);
+      expect.float(b).toBeCloseTo(0.0);
+    });
   });
   test("makeArgb", ({expect}) => {
     let color = Color.makeArgb(0x1Al, 0x1Bl, 0x1Cl, 0x1Dl);


### PR DESCRIPTION
The `Color` module is used heavily across hot paths in rendering in Revery - and because it is represented as an unsigned 32-bit integer under the hood, we should be able to use it with minimal overhead.

__Initial benchmark results:__
```
|------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
|  Color: makeArgb       |  100000     |  0.00161719322205   |  1         |  0         |  300027       |  25        |  25           |
|------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
|  Color: getA           |  100000     |  0.00242209434509   |  1         |  0         |  300027       |  25        |  25           |
+-----------------------------------------------------------------------------------------------------------------------------------+
|  Paint: setColor       |  100000     |  0.000838994979858  |  0         |  0         |  27           |  0         |  0            |
|------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
```

__After switching to raw bindings:__
```
|------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
|  Color: makeArgb       |  100000     |  0.000489950180054  |  2         |  0         |  300033       |  25        |  25           |
|------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
|  Color: getA           |  100000     |  0.000460863113403  |  2         |  0         |  300033       |  25        |  25           |
+-----------------------------------------------------------------------------------------------------------------------------------+
|  Paint: setColor          |  100000     |  0.000483989715576  |  0         |  0         |  27           |  0         |  0            |
|---------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
```

__TODO:__
- [x] Fix perf regression in `Paint.setColor`(now even faster!)