### PR TITLE
Perf: Add Paint benchmarks

### DIFF
--- a/bench/lib/PaintBench.re
+++ b/bench/lib/PaintBench.re
@@ -1,0 +1,24 @@
+open BenchFramework;
+
+open Skia;
+
+let options = Reperf.Options.create(~iterations=100000, ());
+
+module Data = {
+  let initialPaint = Paint.make();
+  let initialColor = Color.makeArgb(0xFF, 0xFF, 0xFF, 0xFF);
+};
+
+let make = () => {
+  let _: Paint.t = Paint.make();
+  ();
+};
+
+let setColor = () => {
+  let () = Paint.setColor(Data.initialPaint, Data.initialColor);
+  ();
+};
+
+bench(~name="Paint: make", ~options, ~setup=() => (), ~f=make, ());
+
+bench(~name="Paint: setColor", ~options, ~setup=() => (), ~f=setColor, ());


### PR DESCRIPTION
Add benchmark for `Paint` - current measurements:

```
|------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
|  Paint: make           |  100000     |  0.0277879238129    |  4         |  0         |  900043       |  786445    |  786445       |
|------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
|  Paint: setColor       |  100000     |  0.000838994979858  |  0         |  0         |  27           |  0         |  0            |
|------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
````