### PR TITLE
Perf: Canvas.drawRectLtwh

### DIFF
--- a/bench/lib/CanvasBench.re
+++ b/bench/lib/CanvasBench.re
@@ -1,0 +1,28 @@
+open BenchFramework;
+
+open Skia;
+
+let options = Reperf.Options.create(~iterations=100000, ());
+
+module Data = {
+  let makeSurface = (width, height) => {
+    let imageInfo = ImageInfo.make(width, height, Rgba8888, Premul, None);
+    Surface.makeRaster(imageInfo, 0, None);
+  };
+
+  let surface = makeSurface(800l, 600l);
+  let canvas = Surface.getCanvas(surface);
+  let paint = Paint.make();
+};
+
+let drawRectLtwh = () => {
+  Skia.Canvas.drawRectLtwh(Data.canvas, 1.0, 2.0, 100., 200., Data.paint);
+};
+
+bench(
+  ~name="Canvas: drawRectLtwh",
+  ~options,
+  ~setup=() => (),
+  ~f=drawRectLtwh,
+  (),
+);


### PR DESCRIPTION
Add benchmark for `Canvas.drawRectLtwh` and see if we can squeeze any more perf out with a direct binding

```
|---------------------------+-------------+---------------------+------------+------------+---------------+------------+---------------|
|  Canvas: drawRectLtwh     |  100000     |  0.388250827789     |  0         |  0         |  27           |  0         |  0            |
+--------------------------------------------------------------------------------------------------------------------------------------+
```

Interestingly, with a raw binding, there wasn't much change (and the allocations are already very low) - so I'll leave this as-is.