### PR TITLE
API: Update Gr.Gl.Interface methods to properly model null/None

### DIFF
--- a/example-sdl/TestSdl.re
+++ b/example-sdl/TestSdl.re
@@ -2,11 +2,25 @@ open Skia;
 
 let ctx = ref(None);
 
+let printEnv = env =>
+  switch (Sys.getenv_opt(env)) {
+  | None => print_endline(env ++ " : not defined ")
+  | Some(v) => print_endline(env ++ " : " ++ v)
+  };
+
+printEnv("WAYLAND_DISPLAY");
+printEnv("XDG_SESSION_TYPE");
+
 let createSkiaGraphicsContext = (window: Sdl2.Window.t) => {
   print_endline("Creating graphics context");
+  let nativeInterface = Skia.Gr.Gl.Interface.makeNative();
+  switch (nativeInterface) {
+  | Some(_) => print_endline("Native interface created successfully.")
+  | None => print_endline("Native interface is null")
+  };
   let interface = Skia.Gr.Gl.Interface.makeSdl2();
   print_endline("Have interface...");
-  let context = Skia.Gr.Context.makeGl(Some(interface));
+  let context = Skia.Gr.Context.makeGl(interface);
 
   switch (context) {
   | None => failwith("Unable to create graphics context")

--- a/src/Skia.rei
+++ b/src/Skia.rei
@@ -294,8 +294,8 @@ module Gr: {
     module Interface: {
       type t;
 
-      let makeNative: unit => t;
-      let makeSdl2: unit => t;
+      let makeNative: unit => option(t);
+      let makeSdl2: unit => option(t);
     };
 
     module FramebufferInfo: {

--- a/src/wrapped/bindings/SkiaWrappedBindings.re
+++ b/src/wrapped/bindings/SkiaWrappedBindings.re
@@ -560,11 +560,14 @@ module M = (F: FOREIGN) => {
         let makeNative =
           foreign(
             "gr_glinterface_create_native_interface",
-            void @-> returning(t),
+            void @-> returning(ptr_opt(SkiaTypes.Gr.Gl.Interface.t)),
           );
 
         let makeSdl2 =
-          foreign("reason_skia_make_sdl2_interface", void @-> returning(t));
+          foreign(
+            "reason_skia_make_sdl2_interface",
+            void @-> returning(ptr_opt(SkiaTypes.Gr.Gl.Interface.t)),
+          );
       };
 
       module FramebufferInfo = {


### PR DESCRIPTION
This updates the `Gr.Gl.Interface.makeNative` and `Gr.Gl.Interface.makeSdl2` to return `None` in the case where an interface could not be created.

This will allow us to update Revery to try the native strategy first, and if that fails, fall-back to SDL2 (as a fix for https://github.com/revery-ui/revery/issues/759)