### PR TITLE
[chore] format .c and .h files with clang-format

### DIFF
--- a/.ci/esy-check-hygiene.yml
+++ b/.ci/esy-check-hygiene.yml
@@ -3,8 +3,14 @@
 steps:
   - script: npm install -g esy@0.6.2
     displayName: 'npm install -g esy@0.6.2'
+  - script: npm install -g clang-format
+    displayName: 'npm install -g clang-format'
   - script: esy install
     displayName: 'esy install'
+  - script: clang-format -i src/wrapped/lib/*.c
+    displayName: 'clang-format -i src/wrapped/lib/*.c'
+  - script: clang-format -i src/wrapped/c/*.c
+    displayName: 'clang-format -i src/wrapped/c/*.c'
   - script: git diff --exit-code
     displayName: 'check that `esy.lock` is up-to-date. If this fails, commit `esy.lock` changes and re-submit PR.'
   - script: esy @test

--- a/.ci/esy-check-hygiene.yml
+++ b/.ci/esy-check-hygiene.yml
@@ -9,6 +9,8 @@ steps:
     displayName: 'clang-format -i src/wrapped/lib/*.c'
   - script: clang-format -i src/wrapped/c/*.c
     displayName: 'clang-format -i src/wrapped/c/*.c'
+  - script: clang-format -i src/wrapped/c/*.h
+    displayName: 'clang-format -i src/wrapped/c/*.h'
   - script: git diff --exit-code
     displayName: 'check that C code is formatted. If this fails, run `clang-format` on modified C files and commit.'
   - script: esy install

--- a/.ci/esy-check-hygiene.yml
+++ b/.ci/esy-check-hygiene.yml
@@ -5,12 +5,14 @@ steps:
     displayName: 'npm install -g esy@0.6.2'
   - script: npm install -g clang-format
     displayName: 'npm install -g clang-format'
-  - script: esy install
-    displayName: 'esy install'
   - script: clang-format -i src/wrapped/lib/*.c
     displayName: 'clang-format -i src/wrapped/lib/*.c'
   - script: clang-format -i src/wrapped/c/*.c
     displayName: 'clang-format -i src/wrapped/c/*.c'
+  - script: git diff --exit-code
+    displayName: 'check that C code is formatted. If this fails, run `clang-format` on modified C files and commit.'
+  - script: esy install
+    displayName: 'esy install'
   - script: git diff --exit-code
     displayName: 'check that `esy.lock` is up-to-date. If this fails, commit `esy.lock` changes and re-submit PR.'
   - script: esy @test

--- a/src/wrapped/c/c_stubs.c
+++ b/src/wrapped/c/c_stubs.c
@@ -1,29 +1,32 @@
 /*
- * Use this file for building any C-layer functionality that we want to keep out of Reason
+ * Use this file for building any C-layer functionality that we want to keep out
+ * of Reason
  */
 
 #include "c_stubs.h"
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 
-void reason_skia_stub_sk_canvas_draw_rect_ltwh(
-sk_canvas_t *canvas, float left, float top, float width, float height, sk_paint_t *paint) 
-{
-    sk_rect_t rect;
-    rect.left = left;
-    rect.top = top;
-    rect.right = left + width;
-    rect.bottom = top + height;
+void reason_skia_stub_sk_canvas_draw_rect_ltwh(sk_canvas_t *canvas, float left,
+                                               float top, float width,
+                                               float height,
+                                               sk_paint_t *paint) {
+  sk_rect_t rect;
+  rect.left = left;
+  rect.top = top;
+  rect.right = left + width;
+  rect.bottom = top + height;
 
-    sk_canvas_draw_rect(canvas, &rect, paint);
+  sk_canvas_draw_rect(canvas, &rect, paint);
 }
 
-void* reason_skia_sdl2_get(void *ctx, const char name[]) {
-    return SDL_GL_GetProcAddress(name);
+void *reason_skia_sdl2_get(void *ctx, const char name[]) {
+  return SDL_GL_GetProcAddress(name);
 };
 
-gr_glinterface_t* reason_skia_make_sdl2_interface() {
-	gr_glinterface_t* interface = gr_glinterface_assemble_gl_interface(0, reason_skia_sdl2_get);
-    return interface;
+gr_glinterface_t *reason_skia_make_sdl2_interface() {
+  gr_glinterface_t *interface =
+      gr_glinterface_assemble_gl_interface(0, reason_skia_sdl2_get);
+  return interface;
 }

--- a/src/wrapped/c/c_stubs.h
+++ b/src/wrapped/c/c_stubs.h
@@ -1,10 +1,12 @@
+#include "gr_context.h"
 #include "sk_canvas.h"
 #include "sk_paint.h"
 #include "sk_types.h"
-#include "gr_context.h"
 
 #include <SDL2/SDL.h>
 
-void reason_skia_stub_sk_canvas_draw_rect_ltwh(sk_canvas_t *canvas, float left, float top, float width, float height, sk_paint_t* paint);
+void reason_skia_stub_sk_canvas_draw_rect_ltwh(sk_canvas_t *canvas, float left,
+                                               float top, float width,
+                                               float height, sk_paint_t *paint);
 
-gr_glinterface_t* reason_skia_make_sdl2_interface();
+gr_glinterface_t *reason_skia_make_sdl2_interface();

--- a/src/wrapped/lib/raw_bindings.c
+++ b/src/wrapped/lib/raw_bindings.c
@@ -10,331 +10,232 @@
 #include "sk_paint.h"
 #include "sk_types.h"
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "ctypes_cstubs_internals.h"
 
-CAMLprim value reason_skia_paint_set_color(
-    value vPaint,
-    int32_t color)
-{
-   sk_paint_t *pPaint = CTYPES_ADDR_OF_FATPTR(vPaint);
-   sk_paint_set_color(pPaint, color);
-   return Val_unit;
+CAMLprim value reason_skia_paint_set_color(value vPaint, int32_t color) {
+  sk_paint_t *pPaint = CTYPES_ADDR_OF_FATPTR(vPaint);
+  sk_paint_set_color(pPaint, color);
+  return Val_unit;
 }
 
-CAMLprim value reason_skia_paint_set_alphaf(value vPaint, double alpha)
-{
-   sk_paint_t *pPaint = CTYPES_ADDR_OF_FATPTR(vPaint);
+CAMLprim value reason_skia_paint_set_alphaf(value vPaint, double alpha) {
+  sk_paint_t *pPaint = CTYPES_ADDR_OF_FATPTR(vPaint);
 
-   int a = (int)(255.0 * alpha);
-   sk_color_t c = sk_paint_get_color(pPaint);
+  int a = (int)(255.0 * alpha);
+  sk_color_t c = sk_paint_get_color(pPaint);
 
-   sk_paint_set_color(
-       pPaint,
-       sk_color_set_argb(
-           a,
-           sk_color_get_r(c),
-           sk_color_get_g(c),
-           sk_color_get_b(c)));
+  sk_paint_set_color(pPaint,
+                     sk_color_set_argb(a, sk_color_get_r(c), sk_color_get_g(c),
+                                       sk_color_get_b(c)));
 
-   sk_color_t newColor = sk_paint_get_color(pPaint);
+  sk_color_t newColor = sk_paint_get_color(pPaint);
 
-   return Val_unit;
+  return Val_unit;
 }
 
-CAMLprim value reason_skia_paint_set_alphaf_byte(value vPaint, value vAlpha)
-{
-   reason_skia_paint_set_alphaf(vPaint, Double_val(vAlpha));
-   return Val_unit;
+CAMLprim value reason_skia_paint_set_alphaf_byte(value vPaint, value vAlpha) {
+  reason_skia_paint_set_alphaf(vPaint, Double_val(vAlpha));
+  return Val_unit;
 }
 
-CAMLprim value reason_skia_matrix_set_color_byte(
-    value vPaint,
-    value vColor)
-{
-   return reason_skia_paint_set_color(
-       vPaint,
-       Int_val(vColor));
+CAMLprim value reason_skia_matrix_set_color_byte(value vPaint, value vColor) {
+  return reason_skia_paint_set_color(vPaint, Int_val(vColor));
 }
 
-double reason_skia_stub_sk_color_float_get_b(int32_t color)
-{
-   return (double)(sk_color_get_b(color) / 255.0);
+double reason_skia_stub_sk_color_float_get_b(int32_t color) {
+  return (double)(sk_color_get_b(color) / 255.0);
 }
 
-CAMLprim value reason_skia_stub_sk_color_float_get_b_byte(value vColor)
-{
-   return caml_copy_double(reason_skia_stub_sk_color_float_get_b(
-       Int_val(vColor)));
+CAMLprim value reason_skia_stub_sk_color_float_get_b_byte(value vColor) {
+  return caml_copy_double(
+      reason_skia_stub_sk_color_float_get_b(Int_val(vColor)));
 }
 
-double reason_skia_stub_sk_color_float_get_g(int32_t color)
-{
-   return (double)(sk_color_get_g(color) / 255.0);
+double reason_skia_stub_sk_color_float_get_g(int32_t color) {
+  return (double)(sk_color_get_g(color) / 255.0);
 }
 
-CAMLprim value reason_skia_stub_sk_color_float_get_g_byte(value vColor)
-{
-   return caml_copy_double(reason_skia_stub_sk_color_float_get_g(
-       Int_val(vColor)));
+CAMLprim value reason_skia_stub_sk_color_float_get_g_byte(value vColor) {
+  return caml_copy_double(
+      reason_skia_stub_sk_color_float_get_g(Int_val(vColor)));
 }
 
-double reason_skia_stub_sk_color_float_get_r(int32_t color)
-{
-   return (double)(sk_color_get_r(color) / 255.0);
+double reason_skia_stub_sk_color_float_get_r(int32_t color) {
+  return (double)(sk_color_get_r(color) / 255.0);
 }
 
-CAMLprim value reason_skia_stub_sk_color_float_get_r_byte(value vColor)
-{
-   return caml_copy_double(reason_skia_stub_sk_color_float_get_r(
-       Int_val(vColor)));
+CAMLprim value reason_skia_stub_sk_color_float_get_r_byte(value vColor) {
+  return caml_copy_double(
+      reason_skia_stub_sk_color_float_get_r(Int_val(vColor)));
 }
 
-double reason_skia_stub_sk_color_float_get_a(int32_t color)
-{
-   return (double)(sk_color_get_a(color) / 255.0);
+double reason_skia_stub_sk_color_float_get_a(int32_t color) {
+  return (double)(sk_color_get_a(color) / 255.0);
 }
 
-CAMLprim value reason_skia_stub_sk_color_float_get_a_byte(value vColor)
-{
-   return caml_copy_double(reason_skia_stub_sk_color_float_get_a(
-       Int_val(vColor)));
+CAMLprim value reason_skia_stub_sk_color_float_get_a_byte(value vColor) {
+  return caml_copy_double(
+      reason_skia_stub_sk_color_float_get_a(Int_val(vColor)));
 }
 
-uint32_t reason_skia_color_float_make_argb(
-    double a,
-    double r,
-    double g,
-    double b)
-{
-   int iA = (int)(255.0 * a);
-   int iR = (int)(255.0 * r);
-   int iG = (int)(255.0 * g);
-   int iB = (int)(255.0 * b);
-   return (uint32_t)sk_color_set_argb(iA, iR, iG, iB);
+uint32_t reason_skia_color_float_make_argb(double a, double r, double g,
+                                           double b) {
+  int iA = (int)(255.0 * a);
+  int iR = (int)(255.0 * r);
+  int iG = (int)(255.0 * g);
+  int iB = (int)(255.0 * b);
+  return (uint32_t)sk_color_set_argb(iA, iR, iG, iB);
 }
 
-CAMLprim value reason_skia_color_float_make_argb_byte(
-    value vA,
-    value vR,
-    value vG,
-    value vB)
-{
-   return Val_int(reason_skia_color_float_make_argb(
-       Double_val(vA),
-       Double_val(vR),
-       Double_val(vG),
-       Double_val(vB)));
+CAMLprim value reason_skia_color_float_make_argb_byte(value vA, value vR,
+                                                      value vG, value vB) {
+  return Val_int(reason_skia_color_float_make_argb(
+      Double_val(vA), Double_val(vR), Double_val(vG), Double_val(vB)));
 }
 
-uint32_t reason_skia_stub_sk_color_get_a(int32_t color)
-{
-   return (uint32_t)sk_color_get_a(color);
+uint32_t reason_skia_stub_sk_color_get_a(int32_t color) {
+  return (uint32_t)sk_color_get_a(color);
 }
 
-CAMLprim value reason_skia_stub_sk_color_get_a_byte(value vColor)
-{
-   return Val_int(reason_skia_stub_sk_color_get_a(
-       Int_val(vColor)));
+CAMLprim value reason_skia_stub_sk_color_get_a_byte(value vColor) {
+  return Val_int(reason_skia_stub_sk_color_get_a(Int_val(vColor)));
 }
 
-uint32_t reason_skia_stub_sk_color_get_r(int32_t color)
-{
-   return (uint32_t)sk_color_get_r(color);
+uint32_t reason_skia_stub_sk_color_get_r(int32_t color) {
+  return (uint32_t)sk_color_get_r(color);
 }
 
-CAMLprim value reason_skia_stub_sk_color_get_r_byte(value vColor)
-{
-   return Val_int(reason_skia_stub_sk_color_get_r(
-       Int_val(vColor)));
+CAMLprim value reason_skia_stub_sk_color_get_r_byte(value vColor) {
+  return Val_int(reason_skia_stub_sk_color_get_r(Int_val(vColor)));
 }
 
-uint32_t reason_skia_stub_sk_color_get_g(int32_t color)
-{
-   return (uint32_t)sk_color_get_g(color);
+uint32_t reason_skia_stub_sk_color_get_g(int32_t color) {
+  return (uint32_t)sk_color_get_g(color);
 }
 
-CAMLprim value reason_skia_stub_sk_color_get_g_byte(value vColor)
-{
-   return Val_int(reason_skia_stub_sk_color_get_g(
-       Int_val(vColor)));
+CAMLprim value reason_skia_stub_sk_color_get_g_byte(value vColor) {
+  return Val_int(reason_skia_stub_sk_color_get_g(Int_val(vColor)));
 }
 
-uint32_t reason_skia_stub_sk_color_get_b(int32_t color)
-{
-   return (uint32_t)sk_color_get_b(color);
+uint32_t reason_skia_stub_sk_color_get_b(int32_t color) {
+  return (uint32_t)sk_color_get_b(color);
 }
 
-CAMLprim value reason_skia_stub_sk_color_get_b_byte(value vColor)
-{
-   return Val_int(reason_skia_stub_sk_color_get_b(
-       Int_val(vColor)));
+CAMLprim value reason_skia_stub_sk_color_get_b_byte(value vColor) {
+  return Val_int(reason_skia_stub_sk_color_get_b(Int_val(vColor)));
 }
 
-uint32_t reason_skia_stub_sk_color_set_argb(
-    int32_t alpha,
-    int32_t red,
-    int32_t green,
-    int32_t blue)
-{
-   return (uint32_t)sk_color_set_argb(alpha, red, green, blue);
+uint32_t reason_skia_stub_sk_color_set_argb(int32_t alpha, int32_t red,
+                                            int32_t green, int32_t blue) {
+  return (uint32_t)sk_color_set_argb(alpha, red, green, blue);
 }
 
-CAMLprim value reason_skia_stub_sk_color_set_argb_byte(
-    value vAlpha,
-    value vRed,
-    value vGreen,
-    value vBlue)
-{
-   return Val_int(reason_skia_stub_sk_color_set_argb(
-       Int_val(vAlpha),
-       Int_val(vRed),
-       Int_val(vGreen),
-       Int_val(vBlue)));
+CAMLprim value reason_skia_stub_sk_color_set_argb_byte(value vAlpha, value vRed,
+                                                       value vGreen,
+                                                       value vBlue) {
+  return Val_int(reason_skia_stub_sk_color_set_argb(
+      Int_val(vAlpha), Int_val(vRed), Int_val(vGreen), Int_val(vBlue)));
 }
 
-double reason_skia_rect_get_bottom(
-    value vRect)
-{
-   sk_rect_t *pRect = CTYPES_ADDR_OF_FATPTR(vRect);
-   return (double)pRect->bottom;
+double reason_skia_rect_get_bottom(value vRect) {
+  sk_rect_t *pRect = CTYPES_ADDR_OF_FATPTR(vRect);
+  return (double)pRect->bottom;
 }
 
-CAMLprim value reason_skia_rect_get_bottom_byte(
-    value vRect)
-{
-   return caml_copy_double(reason_skia_rect_get_bottom(vRect));
+CAMLprim value reason_skia_rect_get_bottom_byte(value vRect) {
+  return caml_copy_double(reason_skia_rect_get_bottom(vRect));
 }
 
-double reason_skia_rect_get_right(
-    value vRect)
-{
-   sk_rect_t *pRect = CTYPES_ADDR_OF_FATPTR(vRect);
-   return (double)pRect->right;
+double reason_skia_rect_get_right(value vRect) {
+  sk_rect_t *pRect = CTYPES_ADDR_OF_FATPTR(vRect);
+  return (double)pRect->right;
 }
 
-CAMLprim value reason_skia_rect_get_right_byte(
-    value vRect)
-{
-   return caml_copy_double(reason_skia_rect_get_right(vRect));
+CAMLprim value reason_skia_rect_get_right_byte(value vRect) {
+  return caml_copy_double(reason_skia_rect_get_right(vRect));
 }
 
-double reason_skia_rect_get_top(
-    value vRect)
-{
-   sk_rect_t *pRect = CTYPES_ADDR_OF_FATPTR(vRect);
-   return (double)pRect->top;
+double reason_skia_rect_get_top(value vRect) {
+  sk_rect_t *pRect = CTYPES_ADDR_OF_FATPTR(vRect);
+  return (double)pRect->top;
 }
 
-CAMLprim value reason_skia_rect_get_top_byte(
-    value vRect)
-{
-   return caml_copy_double(reason_skia_rect_get_top(vRect));
+CAMLprim value reason_skia_rect_get_top_byte(value vRect) {
+  return caml_copy_double(reason_skia_rect_get_top(vRect));
 }
 
-double reason_skia_rect_get_left(
-    value vRect)
-{
-   sk_rect_t *pRect = CTYPES_ADDR_OF_FATPTR(vRect);
-   return (double)pRect->left;
+double reason_skia_rect_get_left(value vRect) {
+  sk_rect_t *pRect = CTYPES_ADDR_OF_FATPTR(vRect);
+  return (double)pRect->left;
 }
 
-CAMLprim value reason_skia_rect_get_left_byte(
-    value vRect)
-{
-   return caml_copy_double(reason_skia_rect_get_left(vRect));
+CAMLprim value reason_skia_rect_get_left_byte(value vRect) {
+  return caml_copy_double(reason_skia_rect_get_left(vRect));
 }
 
-CAMLprim value reason_skia_rect_set(
-    value vRect,
-    double left,
-    double top,
-    double right,
-    double bottom)
-{
-   sk_rect_t *pRect = CTYPES_ADDR_OF_FATPTR(vRect);
-   pRect->left = left;
-   pRect->top = top;
-   pRect->right = right;
-   pRect->bottom = bottom;
+CAMLprim value reason_skia_rect_set(value vRect, double left, double top,
+                                    double right, double bottom) {
+  sk_rect_t *pRect = CTYPES_ADDR_OF_FATPTR(vRect);
+  pRect->left = left;
+  pRect->top = top;
+  pRect->right = right;
+  pRect->bottom = bottom;
 
-   return Val_unit;
+  return Val_unit;
 }
 
-CAMLprim value reasion_skia_rect_set_byte(
-    value vRect,
-    value vLeft,
-    value vTop,
-    value vRight,
-    value vBottom)
-{
-   return reason_skia_rect_set(vRect,
-                               Double_val(vLeft),
-                               Double_val(vTop),
-                               Double_val(vRight),
-                               Double_val(vBottom));
+CAMLprim value reasion_skia_rect_set_byte(value vRect, value vLeft, value vTop,
+                                          value vRight, value vBottom) {
+  return reason_skia_rect_set(vRect, Double_val(vLeft), Double_val(vTop),
+                              Double_val(vRight), Double_val(vBottom));
 }
 
-CAMLprim value reason_skia_matrix_set_scale(
-    value vMatrix,
-    double scaleX,
-    double scaleY,
-    double pivotX,
-    double pivotY)
-{
-   float *pMatrix = CTYPES_ADDR_OF_FATPTR(vMatrix);
-   pMatrix[0] = scaleX;
-   pMatrix[1] = 0.0;
-   pMatrix[2] = pivotX - (scaleX * pivotX);
-   pMatrix[3] = 0.0;
-   pMatrix[4] = scaleY;
-   pMatrix[5] = pivotY - (scaleY * pivotY);
-   pMatrix[6] = 0.0;
-   pMatrix[7] = 0.0;
-   pMatrix[8] = 1.0;
-   return Val_unit;
+CAMLprim value reason_skia_matrix_set_scale(value vMatrix, double scaleX,
+                                            double scaleY, double pivotX,
+                                            double pivotY) {
+  float *pMatrix = CTYPES_ADDR_OF_FATPTR(vMatrix);
+  pMatrix[0] = scaleX;
+  pMatrix[1] = 0.0;
+  pMatrix[2] = pivotX - (scaleX * pivotX);
+  pMatrix[3] = 0.0;
+  pMatrix[4] = scaleY;
+  pMatrix[5] = pivotY - (scaleY * pivotY);
+  pMatrix[6] = 0.0;
+  pMatrix[7] = 0.0;
+  pMatrix[8] = 1.0;
+  return Val_unit;
 }
 
-CAMLprim value reason_skia_matrix_set_scale_byte(
-    value vMatrix,
-    value vScaleX,
-    value vScaleY,
-    value vPivotX,
-    value vPivotY)
-{
-   return reason_skia_matrix_set_scale(vMatrix,
-                                       Double_val(vScaleX),
-                                       Double_val(vScaleY),
-                                       Double_val(vPivotX),
-                                       Double_val(vPivotY));
+CAMLprim value reason_skia_matrix_set_scale_byte(value vMatrix, value vScaleX,
+                                                 value vScaleY, value vPivotX,
+                                                 value vPivotY) {
+  return reason_skia_matrix_set_scale(vMatrix, Double_val(vScaleX),
+                                      Double_val(vScaleY), Double_val(vPivotX),
+                                      Double_val(vPivotY));
 }
 
-CAMLprim value reason_skia_matrix_set_translate(
-    value vMatrix,
-    double translateX,
-    double translateY)
-{
-   float *pMatrix = CTYPES_ADDR_OF_FATPTR(vMatrix);
-   pMatrix[0] = 1.0;
-   pMatrix[1] = 0.0;
-   pMatrix[2] = translateX;
-   pMatrix[3] = 0.0;
-   pMatrix[4] = 1.0;
-   pMatrix[5] = translateY;
-   pMatrix[6] = 0.0;
-   pMatrix[7] = 0.0;
-   pMatrix[8] = 1.0;
-   return Val_unit;
+CAMLprim value reason_skia_matrix_set_translate(value vMatrix,
+                                                double translateX,
+                                                double translateY) {
+  float *pMatrix = CTYPES_ADDR_OF_FATPTR(vMatrix);
+  pMatrix[0] = 1.0;
+  pMatrix[1] = 0.0;
+  pMatrix[2] = translateX;
+  pMatrix[3] = 0.0;
+  pMatrix[4] = 1.0;
+  pMatrix[5] = translateY;
+  pMatrix[6] = 0.0;
+  pMatrix[7] = 0.0;
+  pMatrix[8] = 1.0;
+  return Val_unit;
 }
 
-CAMLprim value reason_skia_matrix_set_translate_byte(
-    value vMatrix,
-    value vTranslateX,
-    value vTranslateY)
-{
-   return reason_skia_matrix_set_translate(vMatrix,
-                                           Double_val(vTranslateX),
-                                           Double_val(vTranslateY));
+CAMLprim value reason_skia_matrix_set_translate_byte(value vMatrix,
+                                                     value vTranslateX,
+                                                     value vTranslateY) {
+  return reason_skia_matrix_set_translate(vMatrix, Double_val(vTranslateX),
+                                          Double_val(vTranslateY));
 }


### PR DESCRIPTION
This will make it easier to remove noise from PRs when conflicting formatting has been accidentally applied.