### PR TITLE
Refactor: Make transitive dependencies explicit

### DIFF
--- a/bench.esy.lock/index.json
+++ b/bench.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "676b68a93d306b59a505914babb5dddd",
+  "checksum": "21ee03463ae85df9456a40162f826434",
   "root": "reason-skia@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -77,7 +77,9 @@
         "@opam/ctypes@opam:0.15.1@b0227b2f",
         "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
-      "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.4.0@639d28a3"
+      ]
     },
     "reason-sdl2@2.10.3020@d41d8cd9": {
       "id": "reason-sdl2@2.10.3020@d41d8cd9",

--- a/bench/lib/dune
+++ b/bench/lib/dune
@@ -2,5 +2,9 @@
     (name SkiaBench)
     (public_name skia-bench.lib)
     (ocamlopt_flags -linkall)
-    (libraries skia reperf.lib)
-)
+    (libraries
+        skia
+        skia.wrapped
+        skia.wrapped.bindings
+        reperf.lib
+))

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,3 @@
-(lang dune 1.6)
+(lang dune 1.7)
 (using fmt 1.0 (enabled_for reason))
+(implicit_transitive_deps false)

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "23147f440ddc7e7b15f27b7d6dee4a33",
+  "checksum": "60996506e921bef2c0c50294083ee132",
   "root": "reason-skia@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -57,7 +57,9 @@
         "@opam/ctypes@opam:0.15.1@b0227b2f",
         "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
-      "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.4.0@639d28a3"
+      ]
     },
     "reason-sdl2@2.10.3020@d41d8cd9": {
       "id": "reason-sdl2@2.10.3020@d41d8cd9",

--- a/example-sdl.esy.lock/index.json
+++ b/example-sdl.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "23147f440ddc7e7b15f27b7d6dee4a33",
+  "checksum": "60996506e921bef2c0c50294083ee132",
   "root": "reason-skia@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -57,7 +57,9 @@
         "@opam/ctypes@opam:0.15.1@b0227b2f",
         "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
-      "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.4.0@639d28a3"
+      ]
     },
     "reason-sdl2@2.10.3020@d41d8cd9": {
       "id": "reason-sdl2@2.10.3020@d41d8cd9",

--- a/example-sdl/dune
+++ b/example-sdl/dune
@@ -6,4 +6,7 @@
         skia
         sdl2
         lwt
+        integers
+        skia.wrapped.bindings
+        skia.wrapped
 ))

--- a/example.esy.lock/index.json
+++ b/example.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "23147f440ddc7e7b15f27b7d6dee4a33",
+  "checksum": "60996506e921bef2c0c50294083ee132",
   "root": "reason-skia@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -57,7 +57,9 @@
         "@opam/ctypes@opam:0.15.1@b0227b2f",
         "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
-      "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.4.0@639d28a3"
+      ]
     },
     "reason-sdl2@2.10.3020@d41d8cd9": {
       "id": "reason-sdl2@2.10.3020@d41d8cd9",

--- a/example/dune
+++ b/example/dune
@@ -4,5 +4,7 @@
     (public_names TestApp)
     (libraries
         skia
-	reason-native-crash-utils.asan
-            ))
+        skia.wrapped.bindings
+        skia.wrapped
+        reason-native-crash-utils.asan
+))

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "dune",
         "build",
         "-p",
-	"skia"
+        "skia"
       ]
     ],
     "install": [
@@ -35,6 +35,7 @@
     "reason-native-crash-utils": "github:onivim/reason-native-crash-utils#ae1fd34"
   },
   "devDependencies": {
+    "@opam/dune": "^2.4.0",
     "ocaml": "~4.7.0"
   },
   "resolutions": {

--- a/src/dune
+++ b/src/dune
@@ -8,4 +8,9 @@
   (public_name skia)
   (library_flags (:include flags.sexp))
   (c_library_flags (:include c_library_flags.sexp))
-  (libraries skia.wrapped))
+  (libraries
+    skia.wrapped
+    skia.wrapped.bindings
+    ctypes
+    integers
+))

--- a/src/wrapped/bindings/dune
+++ b/src/wrapped/bindings/dune
@@ -7,4 +7,10 @@
  (name SkiaWrappedBindings)
  (flags -w -9)
  (public_name skia.wrapped.bindings)
- (libraries skia.wrapped.types skia.wrapped.c ctypes.stubs ctypes))
+ (libraries
+    skia.wrapped.types
+    skia.wrapped.c
+    ctypes.stubs
+    ctypes
+    integers
+))

--- a/src/wrapped/lib/dune
+++ b/src/wrapped/lib/dune
@@ -12,7 +12,13 @@
   (name SkiaWrapped)
   (flags (-w -40 -w +26))
   (public_name skia.wrapped)
-  (libraries skia.wrapped.types skia.wrapped.bindings ctypes)
+  (libraries
+    skia.wrapped.types
+    skia.wrapped.bindings
+    skia.wrapped.c
+    ctypes
+    integers
+  )
   (c_names skia_generated_stubs raw_bindings)
   (c_flags (:include ../../c_flags.sexp))
   (c_library_flags (:include ../../c_library_flags.sexp)))

--- a/test.esy.lock/index.json
+++ b/test.esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "8f86c0dc2dd23c745add622410f4ea9a",
+  "checksum": "482f4cf049011cb7b97b33037790e09f",
   "root": "reason-skia@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#cca65f99674ed2d954d28788edeb8c57fada5ed0@d41d8cd9": {
@@ -59,7 +59,9 @@
         "@opam/ctypes@opam:0.15.1@b0227b2f",
         "@esy-ocaml/reason@3.6.0@d41d8cd9"
       ],
-      "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
+      "devDependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.4.0@639d28a3"
+      ]
     },
     "reason-sdl2@2.10.3020@d41d8cd9": {
       "id": "reason-sdl2@2.10.3020@d41d8cd9",

--- a/test/dune
+++ b/test/dune
@@ -3,5 +3,5 @@
     (public_name skia-test)
     (flags (:standard (-w -39)))
     (ocamlopt_flags -linkall -g)
-    (libraries rely.lib skia)
+    (libraries rely.lib rely.internal skia)
 )


### PR DESCRIPTION
This is a bit of an experiment in using `dune`s `(implicit_transitive_deps false)` to force transitive dependencies to be made explicit.

It;s a bit more invasive than you might first think though, as it doesn't just affect modules used directly, but also modules aliased from other projects, in ways that aren't entirely clear to me. It might be that explicitly specifying the interface of aliased modules alleviates this, which usually should be done anyway, And native code dependencies also need to be made explicit.