### PR TITLE
fix(bytecode): make bytecode builds functional

### DIFF
--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -23,6 +23,8 @@ steps:
     displayName: 'esy @example-sdl build'
   - script: esy @example run
     displayName: 'esy @example run'
+  - script: esy @example run-bytecode
+    displayName: 'esy @example run-bytecode'
   - script: esy @bench install
     displayName: 'esy @bench install'
   - script: esy @bench build

--- a/dune-workspace
+++ b/dune-workspace
@@ -1,0 +1,3 @@
+(lang dune 2.0)
+(context (default
+ (disable_dynamically_linked_foreign_archives true)))

--- a/example-sdl.json
+++ b/example-sdl.json
@@ -1,7 +1,8 @@
 {
   "source": "./package.json",
   "scripts": {
-    "run": "esy '@example-sdl' x TestSdl"
+    "run": "esy '@example-sdl' x TestSdl",
+    "run-bytecode": "dune exec example-sdl/TestSdl.bc"
   },
   "override": {
       "build": ["dune build -p skia,skia-example-sdl -j4"],

--- a/example-sdl.json
+++ b/example-sdl.json
@@ -2,7 +2,7 @@
   "source": "./package.json",
   "scripts": {
     "run": "esy '@example-sdl' x TestSdl",
-    "run-bytecode": "dune exec example-sdl/TestSdl.bc"
+    "run-bytecode": "esy b dune exec example-sdl/TestSdl.bc"
   },
   "override": {
       "build": ["dune build -p skia,skia-example-sdl -j4"],

--- a/example-sdl.json
+++ b/example-sdl.json
@@ -2,7 +2,7 @@
   "source": "./package.json",
   "scripts": {
     "run": "esy '@example-sdl' x TestSdl",
-    "run-bytecode": "esy b dune exec example-sdl/TestSdl.bc"
+    "run-bytecode": "esy '@example-sdl' x TestSdl.bc"
   },
   "override": {
       "build": ["dune build -p skia,skia-example-sdl -j4"],

--- a/example-sdl/TestSdl.re
+++ b/example-sdl/TestSdl.re
@@ -114,10 +114,7 @@ let run = () => {
 
     let color = Skia.Color.makeArgb(0xFFl, 0xFFl, 0x00l, 0x00l);
 
-    Skia.Canvas.clear(
-      canvas,
-      color
-    );
+    Skia.Canvas.clear(canvas, color);
 
     let paint = Skia.Paint.make();
     Skia.Paint.setColor(

--- a/example-sdl/TestSdl.re
+++ b/example-sdl/TestSdl.re
@@ -11,7 +11,7 @@ let printEnv = env =>
 printEnv("WAYLAND_DISPLAY");
 printEnv("XDG_SESSION_TYPE");
 
-let createSkiaGraphicsContext = (window: Sdl2.Window.t) => {
+let createSkiaGraphicsContext = (_window: Sdl2.Window.t) => {
   print_endline("Creating graphics context");
   let nativeInterface = Skia.Gr.Gl.Interface.makeNative();
   switch (nativeInterface) {
@@ -91,8 +91,8 @@ let run = () => {
   Sdl2.Window.setTitle(primaryWindow, "reason-skia-sdl2 example");
   Sdl2.Window.setWin32ProcessDPIAware(primaryWindow);
 
-  let scale = Sdl2.Window.getWin32ScaleFactor(primaryWindow);
-  let display = Sdl2.Window.getDisplay(primaryWindow);
+  let _scale = Sdl2.Window.getWin32ScaleFactor(primaryWindow);
+  let _display = Sdl2.Window.getDisplay(primaryWindow);
 
   Sdl2.Window.setSize(primaryWindow, 800, 600);
   Sdl2.Window.center(primaryWindow);
@@ -105,17 +105,26 @@ let run = () => {
 
   let skiaContext = createSkiaGraphicsContext(primaryWindow);
   let skiaSurface = createSkiaSurface(primaryWindow, skiaContext);
+  print_endline("Getting canvas...")
   let canvas = Skia.Surface.getCanvas(skiaSurface);
+  print_endline("Got canvas")
 
   let render = (window, context, surface) => {
     //print_endline("-- Render: start");
     ignore(context);
     ignore(surface);
 
+    print_endline("Making color...");
+    let color = Skia.Color.makeArgb(0xFFl, 0xFFl, 0x00l, 0x00l);
+    print_endline("Color made: " ++ Int32.to_string(color));
+
+
+    print_endline("Clearing canvas...")
     Skia.Canvas.clear(
       canvas,
-      Skia.Color.makeArgb(0xFFl, 0xFFl, 0x00l, 0x00l),
+      color
     );
+    print_endline("Canvas cleared.")
 
     let paint = Skia.Paint.make();
     Skia.Paint.setColor(

--- a/example-sdl/TestSdl.re
+++ b/example-sdl/TestSdl.re
@@ -105,26 +105,19 @@ let run = () => {
 
   let skiaContext = createSkiaGraphicsContext(primaryWindow);
   let skiaSurface = createSkiaSurface(primaryWindow, skiaContext);
-  print_endline("Getting canvas...")
   let canvas = Skia.Surface.getCanvas(skiaSurface);
-  print_endline("Got canvas")
 
   let render = (window, context, surface) => {
     //print_endline("-- Render: start");
     ignore(context);
     ignore(surface);
 
-    print_endline("Making color...");
     let color = Skia.Color.makeArgb(0xFFl, 0xFFl, 0x00l, 0x00l);
-    print_endline("Color made: " ++ Int32.to_string(color));
 
-
-    print_endline("Clearing canvas...")
     Skia.Canvas.clear(
       canvas,
       color
     );
-    print_endline("Canvas cleared.")
 
     let paint = Skia.Paint.make();
     Skia.Paint.setColor(

--- a/example-sdl/dune
+++ b/example-sdl/dune
@@ -1,13 +1,11 @@
 (executables
-    (names TestSdl)
-    (package skia-example-sdl)
-    (public_names TestSdl)
-    (modes native byte)
-    (libraries
-        skia
-        sdl2
-        lwt
-        integers
-        skia.wrapped.bindings
-        skia.wrapped
-))
+ (names TestSdl)
+ (package skia-example-sdl)
+ (public_names TestSdl)
+ (modes native byte)
+ (libraries skia sdl2 lwt integers skia.wrapped.bindings skia.wrapped))
+
+(install
+ (section bin)
+ (package skia-example-sdl)
+ (files TestSdl.bc))

--- a/example-sdl/dune
+++ b/example-sdl/dune
@@ -2,6 +2,7 @@
     (names TestSdl)
     (package skia-example-sdl)
     (public_names TestSdl)
+    (modes native byte)
     (libraries
         skia
         sdl2

--- a/example.json
+++ b/example.json
@@ -1,7 +1,8 @@
 {
   "source": "./package.json",
   "scripts": {
-    "run": "esy '@example' x TestApp"
+    "run": "esy '@example' x TestApp",
+    "run-bytecode": "esy '@example' x TestApp.bc"
   },
   "override": {
       "build": ["dune build -p skia,skia-example -j4"],

--- a/example/TestApp.re
+++ b/example/TestApp.re
@@ -35,7 +35,7 @@ let draw = canvas => {
   Path.cubicTo(path, -490., 50., 1130., 430., 50., 430.);
   Path.lineTo(path, 590., 430.);
   Path.close(path);
-  Path.addCircle(path, 100., 200., 75., ());
+  Path.addCircle(path, 100., 200., ~radius=75., ());
 
   let roundRect = Rect.makeLtrb(300., 400., 240., 280.);
   Path.addRoundRect(path, roundRect, 25., 25., ());

--- a/example/dune
+++ b/example/dune
@@ -2,9 +2,15 @@
     (names TestApp)
     (package skia-example)
     (public_names TestApp)
+    (modes native byte)
     (libraries
         skia
         skia.wrapped.bindings
         skia.wrapped
         reason-native-crash-utils.asan
 ))
+
+(install
+ (section bin)
+ (package skia-example)
+ (files TestApp.bc))

--- a/src/wrapped/lib/raw_bindings.c
+++ b/src/wrapped/lib/raw_bindings.c
@@ -188,7 +188,7 @@ CAMLprim value reason_skia_rect_set(value vRect, double left, double top,
 }
 
 CAMLprim value reason_skia_rect_set_byte(value vRect, value vLeft, value vTop,
-                                          value vRight, value vBottom) {
+                                         value vRight, value vBottom) {
   return reason_skia_rect_set(vRect, Double_val(vLeft), Double_val(vTop),
                               Double_val(vRight), Double_val(vBottom));
 }

--- a/src/wrapped/lib/raw_bindings.c
+++ b/src/wrapped/lib/raw_bindings.c
@@ -41,7 +41,7 @@ CAMLprim value reason_skia_paint_set_alphaf_byte(value vPaint, value vAlpha) {
   return Val_unit;
 }
 
-CAMLprim value reason_skia_matrix_set_color_byte(value vPaint, value vColor) {
+CAMLprim value reason_skia_paint_set_color_byte(value vPaint, value vColor) {
   return reason_skia_paint_set_color(vPaint, Int_val(vColor));
 }
 
@@ -187,7 +187,7 @@ CAMLprim value reason_skia_rect_set(value vRect, double left, double top,
   return Val_unit;
 }
 
-CAMLprim value reasion_skia_rect_set_byte(value vRect, value vLeft, value vTop,
+CAMLprim value reason_skia_rect_set_byte(value vRect, value vLeft, value vTop,
                                           value vRight, value vBottom) {
   return reason_skia_rect_set(vRect, Double_val(vLeft), Double_val(vTop),
                               Double_val(vRight), Double_val(vBottom));

--- a/src/wrapped/lib/raw_bindings.c
+++ b/src/wrapped/lib/raw_bindings.c
@@ -43,7 +43,7 @@ CAMLprim value reason_skia_paint_set_alphaf_byte(value vPaint, value vAlpha) {
 
 CAMLprim value reason_skia_paint_set_color_byte(value vPaint, value vColor) {
   reason_skia_paint_set_color(vPaint, Int32_val(vColor));
-  
+
   return Val_unit;
 }
 

--- a/src/wrapped/lib/raw_bindings.c
+++ b/src/wrapped/lib/raw_bindings.c
@@ -42,7 +42,9 @@ CAMLprim value reason_skia_paint_set_alphaf_byte(value vPaint, value vAlpha) {
 }
 
 CAMLprim value reason_skia_paint_set_color_byte(value vPaint, value vColor) {
-  return reason_skia_paint_set_color(vPaint, Int_val(vColor));
+  reason_skia_paint_set_color(vPaint, Int32_val(vColor));
+  
+  return Val_unit;
 }
 
 double reason_skia_stub_sk_color_float_get_b(int32_t color) {
@@ -51,7 +53,7 @@ double reason_skia_stub_sk_color_float_get_b(int32_t color) {
 
 CAMLprim value reason_skia_stub_sk_color_float_get_b_byte(value vColor) {
   return caml_copy_double(
-      reason_skia_stub_sk_color_float_get_b(Int_val(vColor)));
+      reason_skia_stub_sk_color_float_get_b(Int32_val(vColor)));
 }
 
 double reason_skia_stub_sk_color_float_get_g(int32_t color) {
@@ -60,7 +62,7 @@ double reason_skia_stub_sk_color_float_get_g(int32_t color) {
 
 CAMLprim value reason_skia_stub_sk_color_float_get_g_byte(value vColor) {
   return caml_copy_double(
-      reason_skia_stub_sk_color_float_get_g(Int_val(vColor)));
+      reason_skia_stub_sk_color_float_get_g(Int32_val(vColor)));
 }
 
 double reason_skia_stub_sk_color_float_get_r(int32_t color) {
@@ -69,7 +71,7 @@ double reason_skia_stub_sk_color_float_get_r(int32_t color) {
 
 CAMLprim value reason_skia_stub_sk_color_float_get_r_byte(value vColor) {
   return caml_copy_double(
-      reason_skia_stub_sk_color_float_get_r(Int_val(vColor)));
+      reason_skia_stub_sk_color_float_get_r(Int32_val(vColor)));
 }
 
 double reason_skia_stub_sk_color_float_get_a(int32_t color) {
@@ -78,7 +80,7 @@ double reason_skia_stub_sk_color_float_get_a(int32_t color) {
 
 CAMLprim value reason_skia_stub_sk_color_float_get_a_byte(value vColor) {
   return caml_copy_double(
-      reason_skia_stub_sk_color_float_get_a(Int_val(vColor)));
+      reason_skia_stub_sk_color_float_get_a(Int32_val(vColor)));
 }
 
 uint32_t reason_skia_color_float_make_argb(double a, double r, double g,
@@ -92,7 +94,7 @@ uint32_t reason_skia_color_float_make_argb(double a, double r, double g,
 
 CAMLprim value reason_skia_color_float_make_argb_byte(value vA, value vR,
                                                       value vG, value vB) {
-  return Val_int(reason_skia_color_float_make_argb(
+  return caml_copy_int32(reason_skia_color_float_make_argb(
       Double_val(vA), Double_val(vR), Double_val(vG), Double_val(vB)));
 }
 
@@ -101,7 +103,7 @@ uint32_t reason_skia_stub_sk_color_get_a(int32_t color) {
 }
 
 CAMLprim value reason_skia_stub_sk_color_get_a_byte(value vColor) {
-  return Val_int(reason_skia_stub_sk_color_get_a(Int_val(vColor)));
+  return caml_copy_int32(reason_skia_stub_sk_color_get_a(Int32_val(vColor)));
 }
 
 uint32_t reason_skia_stub_sk_color_get_r(int32_t color) {
@@ -109,7 +111,7 @@ uint32_t reason_skia_stub_sk_color_get_r(int32_t color) {
 }
 
 CAMLprim value reason_skia_stub_sk_color_get_r_byte(value vColor) {
-  return Val_int(reason_skia_stub_sk_color_get_r(Int_val(vColor)));
+  return caml_copy_int32(reason_skia_stub_sk_color_get_r(Int32_val(vColor)));
 }
 
 uint32_t reason_skia_stub_sk_color_get_g(int32_t color) {
@@ -117,7 +119,7 @@ uint32_t reason_skia_stub_sk_color_get_g(int32_t color) {
 }
 
 CAMLprim value reason_skia_stub_sk_color_get_g_byte(value vColor) {
-  return Val_int(reason_skia_stub_sk_color_get_g(Int_val(vColor)));
+  return caml_copy_int32(reason_skia_stub_sk_color_get_g(Int32_val(vColor)));
 }
 
 uint32_t reason_skia_stub_sk_color_get_b(int32_t color) {
@@ -125,7 +127,7 @@ uint32_t reason_skia_stub_sk_color_get_b(int32_t color) {
 }
 
 CAMLprim value reason_skia_stub_sk_color_get_b_byte(value vColor) {
-  return Val_int(reason_skia_stub_sk_color_get_b(Int_val(vColor)));
+  return caml_copy_int32(reason_skia_stub_sk_color_get_b(Int32_val(vColor)));
 }
 
 uint32_t reason_skia_stub_sk_color_set_argb(int32_t alpha, int32_t red,
@@ -136,8 +138,8 @@ uint32_t reason_skia_stub_sk_color_set_argb(int32_t alpha, int32_t red,
 CAMLprim value reason_skia_stub_sk_color_set_argb_byte(value vAlpha, value vRed,
                                                        value vGreen,
                                                        value vBlue) {
-  return Val_int(reason_skia_stub_sk_color_set_argb(
-      Int_val(vAlpha), Int_val(vRed), Int_val(vGreen), Int_val(vBlue)));
+  return caml_copy_int32(reason_skia_stub_sk_color_set_argb(
+      Int32_val(vAlpha), Int32_val(vRed), Int32_val(vGreen), Int32_val(vBlue)));
 }
 
 double reason_skia_rect_get_bottom(value vRect) {


### PR DESCRIPTION
This fixes two typos that were blocking bytecode builds from working:
`reasion_skia_rect_set_byte` => `reason_skia_rect_set_byte`
`reason_skia_matrix_set_color_byte` => `reason_skia_paint_set_color_byte`

These are hard to catch if we don't enable bytecode builds in CI. That's maybe something we should consider 😃 